### PR TITLE
feat: initial featureset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# httpmock - `testify` for HTTP Requests
+
+This package provides a mocking interface in the spirit of [`stretchr/testify/mock`](https://github.com/stretchr/testify/tree/master/mock) for HTTP requests.
+
+## Installation
+
+To install `httpmock`, use `go get`:
+
+```shell
+go get github.com/shawalli/httpmock
+```
+
+## Todo
+
+- [ ] Extend `httptest.Server` to provide a single implementation
+- [ ] Request header matching
+- [ ] Request URL matcher
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ func TestSomething(t *testing.T) {
     defer ts.Close()
 
     // Configure request mocks
-    m.On(http.MethodPut, fmt.Sprintf("%s/foo/1234", server.URL).Body([]byte{`{"bar": "baz"}`}).ReturnStatusNoContent().Once()
+    m.On(http.MethodPut, fmt.Sprintf("%s/foo/1234", server.URL, []byte{`{"bar": "baz"}`}).ReturnStatusNoContent().Once()
 
     // Application code
     c := server.Client()

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ func TestSomething(t *testing.T) {
 }
 ```
 
+You can also use `Mock` directly and implement your own test server. To do so,
+you should wire up your handler so that the request is passed to
+`Mock.Requested(r)`, and respond using the returned `Response`'s `Write(w)`
+method.
+
 ## Installation
 
 To install `httpmock`, use `go get`:
@@ -52,8 +57,8 @@ go get github.com/shawalli/httpmock
 ## Todo
 
 - [x] Extend `httptest.Server` to provide a single implementation
-- [ ] Request header matching
 - [ ] Request URL matcher
+- [ ] Request header matching
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ func TestSomething(t *testing.T) {
     defer ts.Close()
 
     // Configure request mocks
-    m.On(http.MethodPut, fmt.Sprintf("%s/foo/1234", server.URL, []byte{`{"bar": "baz"}`}).ReturnStatusNoContent().Once()
+    m.On(http.MethodPut, fmt.Sprintf("%s/foo/1234?preview=true", server.URL, []byte{`{"bar": "baz"}`}).ReturnStatusNoContent().Once()
 
     // Application code
     c := server.Client()
-    res, err := c.Put("/foo/1234", io.NopCloser(strings.NewReader("{{"bar": "baz"}}")))
+    res, err := c.Put("/foo/1234?preview=true", io.NopCloser(strings.NewReader("{{"bar": "baz"}}")))
 
     // Assert application code
     ...

--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 This package provides a mocking interface in the spirit of [`stretchr/testify/mock`](https://github.com/stretchr/testify/tree/master/mock) for HTTP requests.
 
+```go
+package yours
+
+import (
+    "net/http"
+    "testing"
+    "github.com/shawalli/httpmock"
+)
+
+func TestSomething(t *testing.T) {
+    // Optionally use t for failing instead of panic
+    m := new(httpmock.Mock).Test(t)
+
+    // Setup test server to log requests anre return expected responses
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        request := m.Requested(r)
+        request.WriteResponse(w)
+    })
+    defer ts.Close()
+
+    // Configure request mocks
+    m.On(http.MethodPut, fmt.Sprintf("%s/foo/1234", server.URL).Body([]byte{`{"bar": "baz"}`}).ReturnStatusNoContent().Once()
+
+    // Application code
+    c := server.Client()
+    res, err := c.Put("/foo/1234", io.NopCloser(strings.NewReader("{{"bar": "baz"}}")))
+
+    // Assert application code
+    ...
+
+    // Assert httpmock
+    ...
+}
+```
+
 ## Installation
 
 To install `httpmock`, use `go get`:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/shawalli/httpmock
+
+go 1.22.5
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,14 @@ module github.com/shawalli/httpmock
 
 go 1.22.5
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/google/go-cmp v0.6.0
+	github.com/stretchr/testify v1.9.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,191 @@
+package httpmock
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type Mock struct {
+	ExpectedRequests []*Request
+
+	Requests []Request
+
+	test mock.TestingT
+
+	mutex sync.Mutex
+}
+
+func (m *Mock) On(method string, URL string) *Request {
+	parsedURL, err := url.Parse(URL)
+	if err != nil {
+		m.fail(fmt.Sprintf("failed to parse url. Error: %v\n", err))
+	}
+
+	r := newRequest(
+		m,
+		method,
+		parsedURL,
+	)
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.ExpectedRequests = append(m.ExpectedRequests, r)
+	return r
+}
+
+func (m *Mock) Test(t mock.TestingT) *Mock {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.test = t
+	return m
+}
+
+func (m *Mock) fail(format string, args ...interface{}) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.test == nil {
+		panic(fmt.Sprintf(format, args...))
+	}
+	m.test.Errorf(format, args...)
+	m.test.FailNow()
+}
+
+func (m *Mock) expectedRequests() []*Request {
+	return append([]*Request{}, m.ExpectedRequests...)
+}
+
+// https://goplay.tools/snippet/_1Iu9dcSHKt
+func (m *Mock) findExpectedRequest(actual *http.Request) (int, *Request) {
+	var expectedRequest *Request
+	for i, er := range m.ExpectedRequests {
+		if er.method != AnyMethod && er.method != actual.Method {
+			continue
+		}
+
+		if _, d := er.diffURL(actual); d != 0 {
+			continue
+		}
+
+		if _, d := er.diffBody(actual); d != 0 {
+			continue
+		}
+
+		expectedRequest = er
+		if er.repeatability > -1 {
+			return i, er
+		}
+	}
+
+	return -1, expectedRequest
+}
+
+func (m *Mock) findClosestRequest(other *http.Request) (*Request, string) {
+	var bestMatch matchCandidate
+
+	for _, request := range m.expectedRequests() {
+		errInfo, diffCount := request.diff(other)
+		tempCandidate := matchCandidate{
+			request:   request,
+			mismatch:  errInfo,
+			diffCount: diffCount,
+		}
+		if tempCandidate.isBetterMatchThan(bestMatch) {
+			bestMatch = tempCandidate
+		}
+	}
+
+	return bestMatch.request, bestMatch.mismatch
+}
+
+func (m *Mock) Requested(r *http.Request) *Request {
+	m.mutex.Lock()
+
+	requestBody, err := readHTTPRequestBody(r)
+	if err != nil {
+		m.mutex.Unlock()
+		m.fail("\nassert: httpmock: Failed to read requested body. Error: %v", err)
+	}
+
+	found, request := m.findExpectedRequest(r)
+
+	if found < 0 {
+		// expected request not found, but has already been requested with repeatable times
+		if request != nil {
+			m.mutex.Unlock()
+			m.fail("\nassert: httpmock: The request has been called over %d times.\n\tEither do one more Mock.On(%q, %q), or remove extra request.", request.totalRequests, r.Method, r.URL.String())
+		}
+
+		closestRequest, mismatch := m.findClosestRequest(r)
+		m.mutex.Unlock()
+
+		if closestRequest != nil {
+			tempRequest := &Request{
+				parent: m,
+				method: r.Method,
+				url:    r.URL,
+				body:   requestBody,
+			}
+
+			tmp := "\t" + strings.Join(strings.Split(tempRequest.String(), "\n"), "\n\t")
+			closest := "\t" + strings.Join(strings.Split(closestRequest.String(), "\n"), "\n\t")
+
+			m.fail("\n\nhttpmock: Unexpected Request\n-----------------------------\n\n%s\n\nThe closest request I have is: \n\n%s\nDiff: %s\n",
+				tmp,
+				closest,
+				strings.TrimSpace(mismatch),
+			)
+		} else {
+			m.fail("\nassert: httpmock: I don't know what to return because the request was unexpected.\n\tEither do Mock.On(%q, %q), or remove the request.\n", r.Method, r.URL.String())
+		}
+	}
+
+	if request.repeatability == 1 {
+		request.repeatability = -1
+	} else if request.repeatability > 1 {
+		request.repeatability--
+	}
+	request.totalRequests++
+
+	// add the request
+	nr := newRequest(m, r.Method, r.URL)
+	if requestBody != nil {
+		nr.Body(requestBody)
+	}
+	m.Requests = append(m.Requests, *nr)
+	m.mutex.Unlock()
+
+	return request
+}
+
+type matchCandidate struct {
+	request   *Request
+	mismatch  string
+	diffCount int
+}
+
+func (mc matchCandidate) isBetterMatchThan(other matchCandidate) bool {
+	if mc.request == nil {
+		return false
+	} else if other.request == nil {
+		return true
+	}
+
+	if mc.diffCount > other.diffCount {
+		return false
+	} else if mc.diffCount < other.diffCount {
+		return true
+	}
+
+	if mc.request.repeatability > 0 && other.request.repeatability <= 0 {
+		return true
+	}
+
+	return false
+}

--- a/mock.go
+++ b/mock.go
@@ -105,7 +105,7 @@ func (m *Mock) findClosestRequest(other *http.Request) (*Request, string) {
 	return bestMatch.request, bestMatch.mismatch
 }
 
-func (m *Mock) Requested(r *http.Request) *Request {
+func (m *Mock) Requested(r *http.Request) *Response {
 	m.mutex.Lock()
 
 	requestBody, err := readHTTPRequestBody(r)
@@ -159,7 +159,7 @@ func (m *Mock) Requested(r *http.Request) *Request {
 	m.Requests = append(m.Requests, *nr)
 	m.mutex.Unlock()
 
-	return request
+	return request.response
 }
 
 type matchCandidate struct {

--- a/mock.go
+++ b/mock.go
@@ -231,6 +231,7 @@ func (m *Mock) AssertNumberOfRequests(t mock.TestingT, method string, path strin
 	u.User = nil
 	u.RawQuery = ""
 	u.Fragment = ""
+	u.RawFragment = ""
 	path = u.String()
 
 	m.mutex.Lock()
@@ -241,11 +242,11 @@ func (m *Mock) AssertNumberOfRequests(t mock.TestingT, method string, path strin
 			continue
 		}
 
-		ru := *request.url
-		ru.User = nil
-		ru.RawQuery = ""
-		ru.Fragment = ""
-		if ru.String() != path {
+		rURL := *request.url
+		rURL.User = nil
+		rURL.RawQuery = ""
+		rURL.Fragment = ""
+		if rURL.String() != path {
 			continue
 		}
 
@@ -307,9 +308,9 @@ func (m *Mock) AssertNotRequested(t mock.TestingT, method string, path string, b
 
 func (m *Mock) checkExpectation(request *Request) (bool, string) {
 	if (!m.checkWasRequested(request.method, request.url, request.body) && request.totalRequests == 0) || (request.repeatability > 0) {
-		return false, fmt.Sprintf("FAIL:\t%s %s\n\t(%d) %s", request.method, request.url, len(request.body), bodyFragment(request.body))
+		return false, fmt.Sprintf("FAIL:\t%s %s\n\t(%d) %s", request.method, request.url, len(request.body), trimBody(request.body))
 	}
-	return true, fmt.Sprintf("PASS:\t%s %s\n\t(%d) %s", request.method, request.url, len(request.body), bodyFragment(request.body))
+	return true, fmt.Sprintf("PASS:\t%s %s\n\t(%d) %s", request.method, request.url, len(request.body), trimBody(request.body))
 }
 
 func (m *Mock) checkWasRequested(method string, URL *url.URL, body []byte) bool {

--- a/mock.go
+++ b/mock.go
@@ -20,7 +20,7 @@ type Mock struct {
 	mutex sync.Mutex
 }
 
-func (m *Mock) On(method string, URL string) *Request {
+func (m *Mock) On(method string, URL string, body []byte) *Request {
 	parsedURL, err := url.Parse(URL)
 	if err != nil {
 		m.fail(fmt.Sprintf("failed to parse url. Error: %v\n", err))
@@ -30,6 +30,7 @@ func (m *Mock) On(method string, URL string) *Request {
 		m,
 		method,
 		parsedURL,
+		body,
 	)
 
 	m.mutex.Lock()
@@ -154,10 +155,7 @@ func (m *Mock) Requested(r *http.Request) *Request {
 	request.totalRequests++
 
 	// add the request
-	nr := newRequest(m, r.Method, r.URL)
-	if requestBody != nil {
-		nr.Body(requestBody)
-	}
+	nr := newRequest(m, r.Method, r.URL, requestBody)
 	m.Requests = append(m.Requests, *nr)
 	m.mutex.Unlock()
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -99,8 +99,8 @@ func TestMock_findExpectedRequest_Fail(t *testing.T) {
 			// Setup
 			m := new(Mock)
 			m.On(http.MethodPatch, "https://test.com/bars/1234", []byte(`{"quz": "east"}`))
-			m.On(http.MethodGet, "https://test.com/bars/1234", nil).QueryParam("limit", "1")
-			m.On(http.MethodGet, "https://test.com/bars/1234", nil).QueryParam("limit", "100").QueryParam("page", "2")
+			m.On(http.MethodGet, "https://test.com/bars/1234?limit=1", nil)
+			m.On(http.MethodGet, "https://test.com/bars/1234?limit=100&page=2", nil)
 			m.On(http.MethodPut, "https://test.com/bars/1234", nil)
 
 			// Test
@@ -161,7 +161,7 @@ func TestMock_findExpectedRequest(t *testing.T) {
 			m := new(Mock)
 			m.On(http.MethodPatch, "https://test.com/bars/1234", []byte(`{"quz": "east"}`))
 			m.On(AnyMethod, "https://test.com/foo", nil)
-			m.On(http.MethodGet, "https://test.com/bars/1234", nil).QueryParam("limit", "1")
+			m.On(http.MethodGet, "https://test.com/bars/1234?limit=1", nil)
 			m.On(http.MethodPut, "https://test.com/bars/1234", nil)
 
 			// Test

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,0 +1,504 @@
+package httpmock
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustNewRequest(r *http.Request, err error) *http.Request {
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error making request: %v", err))
+	}
+	return r
+}
+
+func TestMock_DoBadURL(t *testing.T) {
+	// Setup
+	var gotPanic string
+	defer func() {
+		if r := recover(); r != nil {
+			gotPanic = r.(string)
+		}
+	}()
+
+	m := new(Mock)
+
+	// Test
+	m.On(http.MethodGet, "\r")
+
+	// Assertions
+	wantPanic := "failed to parse url"
+	assert.Truef(t, strings.HasPrefix(gotPanic, wantPanic), "panic message %q does not contain %q", gotPanic, wantPanic)
+}
+
+func TestMock_Do(t *testing.T) {
+	// Setup
+	m := new(Mock)
+
+	// Test
+	got := m.On(http.MethodGet, "https://test.com/foo")
+
+	// Assertions
+	assert.Len(t, m.ExpectedRequests, 1)
+	want := &Request{
+		method: http.MethodGet,
+		url: &url.URL{
+			Scheme: "https",
+			Host:   "test.com",
+			Path:   "/foo",
+		},
+		parent: m,
+	}
+	assert.Equal(t, want, got)
+	assert.Equal(t, want, m.ExpectedRequests[0])
+}
+
+func TestMock_findExpectedRequest_Fail(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *http.Request
+	}{
+		{
+			name:    "wrong-method",
+			request: mustNewRequest(http.NewRequest(http.MethodDelete, "https://test.com/bars/1234", http.NoBody)),
+		},
+		{
+			name:    "wrong-path",
+			request: mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/bar", http.NoBody)),
+		},
+		{
+			name:    "wrong-query-param-value",
+			request: mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/bars/1234?limit=2", http.NoBody)),
+		},
+		{
+			name:    "missing-query-param-constraint",
+			request: mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/bars/1234?limit=100", http.NoBody)),
+		},
+		{
+			name:    "missing-body",
+			request: mustNewRequest(http.NewRequest(http.MethodPatch, "https://test.com/bars/1234", http.NoBody)),
+		},
+		{
+			name:    "wrong-body",
+			request: mustNewRequest(http.NewRequest(http.MethodPatch, "https://test.com/bars/1234", io.NopCloser(strings.NewReader(`{"quz": "west"}`)))),
+		},
+		{
+			name:    "extra-body",
+			request: mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/bars/1234", io.NopCloser(strings.NewReader(`{"quz": "west"}`)))),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			m := new(Mock)
+			m.On(http.MethodPatch, "https://test.com/bars/1234").Body([]byte(`{"quz": "east"}`))
+			m.On(http.MethodGet, "https://test.com/bars/1234").QueryParam("limit", "1")
+			m.On(http.MethodGet, "https://test.com/bars/1234").QueryParam("limit", "100").QueryParam("page", "2")
+			m.On(http.MethodPut, "https://test.com/bars/1234")
+
+			// Test
+			gotIndex, gotExpectedRequest := m.findExpectedRequest(tt.request)
+
+			// Assertions
+			assert.Nil(t, gotExpectedRequest)
+			assert.Equal(t, -1, gotIndex)
+		})
+	}
+}
+
+func TestMock_findExpectedRequest_TooManyRepeats(t *testing.T) {
+	// Setup
+	m := new(Mock)
+	m.On(http.MethodDelete, "https://test.com/bars/1234").repeatability = -1
+
+	test := mustNewRequest(http.NewRequest(http.MethodDelete, "https://test.com/bars/1234", http.NoBody))
+
+	// Test
+	gotIndex, gotExpectedResult := m.findExpectedRequest(test)
+
+	// Assertions
+	assert.Equal(t, -1, gotIndex)
+	assert.NotNil(t, gotExpectedResult)
+}
+
+func TestMock_findExpectedRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   *http.Request
+		wantIndex int
+	}{
+		{
+			name:      "any-method",
+			request:   mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/foo", http.NoBody)),
+			wantIndex: 1,
+		},
+		{
+			name:      "no-body",
+			request:   mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/bars/1234", http.NoBody)),
+			wantIndex: 3,
+		}, {
+			name:      "query-param",
+			request:   mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/bars/1234?limit=1", http.NoBody)),
+			wantIndex: 2,
+		},
+		{
+			name:      "body",
+			request:   mustNewRequest(http.NewRequest(http.MethodPatch, "https://test.com/bars/1234", io.NopCloser(strings.NewReader(`{"quz": "east"}`)))),
+			wantIndex: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			m := new(Mock)
+			m.On(http.MethodPatch, "https://test.com/bars/1234").Body([]byte(`{"quz": "east"}`))
+			m.On(AnyMethod, "https://test.com/foo")
+			m.On(http.MethodGet, "https://test.com/bars/1234").QueryParam("limit", "1")
+			m.On(http.MethodPut, "https://test.com/bars/1234")
+
+			// Test
+			gotIndex, gotExpectedRequest := m.findExpectedRequest(tt.request)
+
+			// Assertions
+			assert.NotNil(t, gotExpectedRequest)
+			assert.Equal(t, tt.wantIndex, gotIndex)
+		})
+	}
+}
+
+func TestMock_findClosestRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		mock         func() *Mock
+		test         *http.Request
+		wantRequest  *Request
+		wantMismatch bool
+	}{
+		{
+			name: "no-match",
+			mock: func() *Mock {
+				m := new(Mock)
+				// m.On(http.MethodPut, "/foo")
+				return m
+			},
+			test:         mustNewRequest(http.NewRequest(http.MethodGet, "/foo/bar?limit=3", http.NoBody)),
+			wantRequest:  nil,
+			wantMismatch: false,
+		},
+		{
+			name: "default-match",
+			mock: func() *Mock {
+				m := new(Mock)
+				m.On(http.MethodPut, "/foo")
+				return m
+			},
+			test: mustNewRequest(http.NewRequest(http.MethodGet, "/foo/bar?limit=3", http.NoBody)),
+			wantRequest: &Request{
+				method: http.MethodPut,
+				url:    &url.URL{Path: "/foo"},
+			},
+			wantMismatch: true,
+		},
+		{
+			name: "favor-first-match",
+			mock: func() *Mock {
+				m := new(Mock)
+				m.On(http.MethodPut, "/foo")
+				m.On(http.MethodGet, "/bar")
+				return m
+			},
+			test: mustNewRequest(http.NewRequest(http.MethodGet, "/foo?limit=3", http.NoBody)),
+			wantRequest: &Request{
+				method: http.MethodPut,
+				url:    &url.URL{Path: "/foo"},
+			},
+			wantMismatch: true,
+		},
+		{
+			name: "favor-repeatability",
+			mock: func() *Mock {
+				m := new(Mock)
+				// mark this endpoint as already matched
+				m.On(http.MethodPut, "/foo").repeatability = -1
+				m.On(http.MethodGet, "/bar").Once()
+				return m
+			},
+			test: mustNewRequest(http.NewRequest(http.MethodPut, "/bar", http.NoBody)),
+			wantRequest: &Request{
+				method:        http.MethodGet,
+				url:           &url.URL{Path: "/bar"},
+				repeatability: 1,
+			},
+			wantMismatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			m := tt.mock()
+
+			// Test
+			gotRequest, gotMismatch := m.findClosestRequest(tt.test)
+
+			// Assert
+			if tt.wantRequest != nil {
+				tt.wantRequest.parent = m
+			}
+			assert.Equal(t, tt.wantRequest, gotRequest)
+			assert.Equal(t, tt.wantMismatch, gotMismatch != "")
+		})
+	}
+}
+
+// MockTestingT mocks a test struct
+// Borrowed from testify/mock tests
+type MockTestingT struct {
+	logfCount, errorfCount, failNowCount int
+}
+
+const mockTestingTFailNowCalled = "FailNow was called"
+
+func (m *MockTestingT) Logf(string, ...interface{}) {
+	m.logfCount++
+}
+
+func (m *MockTestingT) Errorf(string, ...interface{}) {
+	m.errorfCount++
+}
+
+func (m *MockTestingT) FailNow() {
+	m.failNowCount++
+
+	// this function should panic now to stop the execution as expected
+	panic(mockTestingTFailNowCalled)
+}
+
+func TestMock_Requested_FailToReadRequestBody(t *testing.T) {
+	// Setup
+	var gotPanic bool
+	defer func() {
+		if r := recover(); r != nil {
+			gotPanic = true
+		}
+	}()
+
+	fakeT := &MockTestingT{}
+	m := new(Mock).Test(fakeT)
+	m.On(http.MethodGet, "https://test.com/foo").ReturnStatusOK()
+
+	test := mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/foo", io.NopCloser(&badReader{})))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.True(t, gotPanic)
+	assert.Equal(t, 1, fakeT.failNowCount)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, got.totalRequests)
+}
+
+func TestMock_Requested_FailToFindAnyMatch(t *testing.T) {
+	// Setup
+	var gotPanic bool
+	defer func() {
+		if r := recover(); r != nil {
+			gotPanic = true
+		}
+	}()
+
+	fakeT := &MockTestingT{}
+	m := new(Mock).Test(fakeT)
+	m.On(http.MethodGet, "https://test.com/foo").ReturnStatusOK()
+
+	test := mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/foo", http.NoBody))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.True(t, gotPanic)
+	assert.Equal(t, 1, fakeT.failNowCount)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, got.totalRequests)
+}
+
+func TestMock_Requested_FailToFindRepeatableMatch(t *testing.T) {
+	// Setup
+	var gotPanic bool
+	defer func() {
+		if r := recover(); r != nil {
+			gotPanic = true
+		}
+	}()
+
+	fakeT := &MockTestingT{}
+	m := new(Mock).Test(fakeT)
+	m.On(http.MethodPut, "https://test.com/foo").ReturnStatusOK().Once()
+
+	test := mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/foo", http.NoBody))
+
+	// Test
+	_ = m.Requested(test)
+	got := m.Requested(test)
+
+	// Assertions
+	assert.True(t, gotPanic)
+	assert.Equal(t, 1, fakeT.failNowCount)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, got.totalRequests)
+}
+
+func TestMock_Requested_FailToFindClosestRequest(t *testing.T) {
+	// Setup
+	var gotPanic bool
+	defer func() {
+		if r := recover(); r != nil {
+			gotPanic = true
+		}
+	}()
+
+	fakeT := &MockTestingT{}
+	m := new(Mock).Test(fakeT)
+
+	test := mustNewRequest(http.NewRequest(http.MethodPut, "https://test.com/foo", http.NoBody))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.True(t, gotPanic)
+	assert.Equal(t, 1, fakeT.failNowCount)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, got.totalRequests)
+}
+
+func TestMock_Requested(t *testing.T) {
+	// Setup
+	m := new(Mock).Test(t)
+	want := m.On(http.MethodGet, "https://test.com/foo").ReturnStatusOK()
+
+	test := mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/foo", http.NoBody))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.Equal(t, want, got)
+	assert.Equal(t, 1, got.totalRequests)
+}
+
+func TestMock_RequestedOnce(t *testing.T) {
+	// Setup
+	m := new(Mock).Test(t)
+	want := m.On(http.MethodGet, "https://test.com/foo").ReturnStatusOK().Once()
+
+	test := mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/foo", http.NoBody))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.Equal(t, want, got)
+	assert.Equal(t, -1, got.repeatability)
+	assert.Equal(t, 1, got.totalRequests)
+}
+
+func TestMock_RequestedTimes(t *testing.T) {
+	// Setup
+	m := new(Mock).Test(t)
+	want := m.On(http.MethodGet, "https://test.com/foo").ReturnStatusOK().Times(4)
+
+	test := mustNewRequest(http.NewRequest(http.MethodGet, "https://test.com/foo", http.NoBody))
+
+	// Test
+	got := m.Requested(test)
+
+	// Assertions
+	assert.Equal(t, want, got)
+	assert.Equal(t, 3, got.repeatability)
+	assert.Equal(t, 1, got.totalRequests)
+}
+
+func TestMatchCandidate_isBetterMatchThan(t *testing.T) {
+	tests := []struct {
+		name  string
+		test  matchCandidate
+		other matchCandidate
+		want  bool
+	}{
+		{
+			name:  "nil-request",
+			test:  matchCandidate{},
+			other: matchCandidate{},
+			want:  false,
+		},
+		{
+			name:  "nil-other-request",
+			test:  matchCandidate{request: &Request{}},
+			other: matchCandidate{},
+			want:  true,
+		},
+		{
+			name:  "higher-diffcount-than-other",
+			test:  matchCandidate{request: &Request{}, diffCount: 3},
+			other: matchCandidate{request: &Request{}, diffCount: 2},
+			want:  false,
+		},
+		{
+			name:  "lower-diffcount-than-other",
+			test:  matchCandidate{request: &Request{}, diffCount: 2},
+			other: matchCandidate{request: &Request{}, diffCount: 3},
+			want:  true,
+		},
+		{
+			name:  "higher-repeatability-than-other",
+			test:  matchCandidate{request: &Request{repeatability: 1}, diffCount: 2},
+			other: matchCandidate{request: &Request{repeatability: -1}, diffCount: 2},
+			want:  true,
+		},
+		{
+			name:  "higher-repeatability-than-other",
+			test:  matchCandidate{request: &Request{repeatability: -1}, diffCount: 2},
+			other: matchCandidate{request: &Request{repeatability: 1}, diffCount: 2},
+			want:  false,
+		},
+		{
+			name:  "equal-repeatability",
+			test:  matchCandidate{request: &Request{repeatability: 1}, diffCount: 2},
+			other: matchCandidate{request: &Request{repeatability: 1}, diffCount: 2},
+			want:  false,
+		},
+		{
+			name:  "negative-other-repeatability",
+			test:  matchCandidate{request: &Request{repeatability: 0}, diffCount: 2},
+			other: matchCandidate{request: &Request{repeatability: -1}, diffCount: 2},
+			want:  false,
+		},
+		{
+			name:  "equal-negative-repeatability",
+			test:  matchCandidate{request: &Request{repeatability: -1}, diffCount: 2},
+			other: matchCandidate{request: &Request{repeatability: -1}, diffCount: 2},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test
+			got := tt.test.isBetterMatchThan(tt.other)
+
+			// Assertions
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -18,8 +18,6 @@ type MockTestingT struct {
 	logfCount, errorfCount, failNowCount int
 }
 
-const mockTestingTFailNowCalled = "FailNow was called"
-
 func (m *MockTestingT) Logf(string, ...interface{}) {
 	m.logfCount++
 }
@@ -28,15 +26,21 @@ func (m *MockTestingT) Errorf(string, ...interface{}) {
 	m.errorfCount++
 }
 
+// FailNow mocks the FailNow call.
+// It panics in order to mimic the FailNow behavior in the sense that
+// the execution stops.
 func (m *MockTestingT) FailNow() {
 	m.failNowCount++
 
 	// this function should panic now to stop the execution as expected
-	panic(mockTestingTFailNowCalled)
+	panic("FailNow was called")
 }
 
 func (m *MockTestingT) Helper() {}
 
+// mustNewRequest is a convenience test helper that wraps a call to
+// http.NewRequest() and panics if an error is returned. It is only
+// intended to be used during test setup.
 func mustNewRequest(r *http.Request, err error) *http.Request {
 	if err != nil {
 		panic(fmt.Sprintf("unexpected error making request: %v", err))
@@ -63,7 +67,7 @@ func TestMock_fail_NoTestingT(t *testing.T) {
 	m.fail("I failed...%s %v", "badly!", errors.New("some error"))
 }
 
-func TestMock_DoBadURL(t *testing.T) {
+func TestMock_On_BadURL(t *testing.T) {
 	// Setup
 	var successfulRequestedCall int
 
@@ -86,7 +90,7 @@ func TestMock_DoBadURL(t *testing.T) {
 	successfulRequestedCall++
 }
 
-func TestMock_Do(t *testing.T) {
+func TestMock_On(t *testing.T) {
 	// Setup
 	m := new(Mock)
 
@@ -296,7 +300,7 @@ func TestMock_findClosestRequest(t *testing.T) {
 			// Test
 			gotRequest, gotMismatch := m.findClosestRequest(tt.test)
 
-			// Assert
+			// Assertions
 			if tt.wantRequest != nil {
 				tt.wantRequest.parent = m
 			}

--- a/mock_test.go
+++ b/mock_test.go
@@ -11,10 +11,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type badReader struct{}
+// MockTestingT mocks a test struct
+// Borrowed from testify/mock tests
+type MockTestingT struct {
+	logfCount, errorfCount, failNowCount int
+}
 
-func (br *badReader) Read(_ []byte) (n int, err error) {
-	return 0, io.ErrUnexpectedEOF
+const mockTestingTFailNowCalled = "FailNow was called"
+
+func (m *MockTestingT) Logf(string, ...interface{}) {
+	m.logfCount++
+}
+
+func (m *MockTestingT) Errorf(string, ...interface{}) {
+	m.errorfCount++
+}
+
+func (m *MockTestingT) FailNow() {
+	m.failNowCount++
+
+	// this function should panic now to stop the execution as expected
+	panic(mockTestingTFailNowCalled)
 }
 
 func mustNewRequest(r *http.Request, err error) *http.Request {
@@ -261,29 +278,6 @@ func TestMock_findClosestRequest(t *testing.T) {
 			assert.Equal(t, tt.wantMismatch, gotMismatch != "")
 		})
 	}
-}
-
-// MockTestingT mocks a test struct
-// Borrowed from testify/mock tests
-type MockTestingT struct {
-	logfCount, errorfCount, failNowCount int
-}
-
-const mockTestingTFailNowCalled = "FailNow was called"
-
-func (m *MockTestingT) Logf(string, ...interface{}) {
-	m.logfCount++
-}
-
-func (m *MockTestingT) Errorf(string, ...interface{}) {
-	m.errorfCount++
-}
-
-func (m *MockTestingT) FailNow() {
-	m.failNowCount++
-
-	// this function should panic now to stop the execution as expected
-	panic(mockTestingTFailNowCalled)
 }
 
 func TestMock_Requested_FailToReadRequestBody(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -60,18 +60,6 @@ func (r *Request) unlock() {
 	r.parent.mutex.Unlock()
 }
 
-func (r *Request) QueryParam(param string, value string) *Request {
-	r.lock()
-	defer r.unlock()
-
-	values := r.url.Query()
-
-	values.Set(param, value)
-	r.url.RawQuery = values.Encode()
-
-	return r
-}
-
 func (r *Request) ReturnStatusCode(statusCode int) *Request {
 	r.lock()
 	defer r.unlock()

--- a/request.go
+++ b/request.go
@@ -1,0 +1,105 @@
+package httpmock
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+var (
+	ErrReturnStatusCode = errors.New("invalid return status code")
+	ErrWriteReturnBody  = errors.New("error writing return body")
+
+	AnyMethod = "mock.AnyMethod"
+)
+
+type Request struct {
+	method string
+	url    *url.URL
+	body   []byte
+
+	returnStatusCode int
+	returnHeaders    *http.Header
+	returnBody       []byte
+}
+
+func newRequest(method string, URL *url.URL) *Request {
+	return &Request{
+		method: method,
+		url:    URL,
+	}
+}
+
+func (r *Request) Body(body []byte) *Request {
+	r.body = body
+
+	return r
+}
+
+func (r *Request) QueryParam(param string, value string) *Request {
+	values := r.url.Query()
+
+	values.Set(param, value)
+	r.url.RawQuery = values.Encode()
+
+	return r
+}
+
+func (r *Request) ReturnStatusCode(statusCode int) *Request {
+	r.returnStatusCode = statusCode
+
+	return r
+}
+
+func (r *Request) ReturnStatusOK() *Request {
+	r.returnStatusCode = http.StatusOK
+
+	return r
+}
+
+func (r *Request) ReturnStatusNoContent() *Request {
+	r.returnStatusCode = http.StatusNoContent
+
+	return r
+}
+
+func (r *Request) ReturnHeaders(header string, value string) *Request {
+	if r.returnHeaders == nil {
+		r.returnHeaders = &http.Header{}
+	}
+
+	r.returnHeaders.Set(header, value)
+
+	return r
+}
+
+func (r *Request) ReturnBody(body []byte) *Request {
+	r.returnBody = body
+
+	return r
+}
+
+func (r *Request) WriteResponse(w http.ResponseWriter) error {
+	if r.returnStatusCode == 0 {
+		return ErrReturnStatusCode
+	}
+
+	if r.returnHeaders != nil {
+		for header, values := range *r.returnHeaders {
+			for _, value := range values {
+				w.Header().Set(header, value)
+			}
+		}
+	}
+
+	w.WriteHeader(r.returnStatusCode)
+
+	if r.returnBody != nil {
+		_, err := w.Write(r.returnBody)
+		if err != nil {
+			return ErrWriteReturnBody
+		}
+	}
+
+	return nil
+}

--- a/request.go
+++ b/request.go
@@ -269,6 +269,17 @@ func readHTTPRequestBody(r *http.Request) ([]byte, error) {
 	return body, nil
 }
 
+func bodyFragment(body []byte) string {
+	o := fmtMissing
+	olen := len(body)
+	if olen > 1024 {
+		o = fmt.Sprintf("%s...", string(body[:1024]))
+	} else if olen > 0 {
+		o = string(body)
+	}
+	return o
+}
+
 func (r *Request) diffBody(other *http.Request) (string, int) {
 	var output string
 	var differences int
@@ -279,20 +290,11 @@ func (r *Request) diffBody(other *http.Request) (string, int) {
 		return err.Error(), 1
 	}
 
-	e := fmtMissing
+	e := bodyFragment(r.body)
 	elen := len(r.body)
-	if elen > 1024 {
-		e = fmt.Sprintf("%s...", string(r.body[:1024]))
-	} else if elen > 0 {
-		e = string(r.body)
-	}
-	a := fmtMissing
+	a := bodyFragment(otherBody)
 	alen := len(otherBody)
-	if alen > 1024 {
-		a = fmt.Sprintf("%s...", string(otherBody[:1024]))
-	} else if alen > 0 {
-		a = string(otherBody)
-	}
+
 	eq := fmtEqual
 	if elen == 0 && alen == 0 {
 		output = fmt.Sprintf("\t%d: PASS:  (0) %s == (0) %s\n", 2, e, a)
@@ -375,14 +377,9 @@ func (r *Request) String() string {
 		output = append(output, fmt.Sprintf("\tFragment: %s", e))
 	}
 
-	e = fmtMissing
+	e = bodyFragment(r.body)
 	elen := len(r.body)
-	if elen > 1024 {
-		e = fmt.Sprintf("(%d) %s...", len(r.body), string(r.body[:1024]))
-	} else if elen > 0 {
-		e = fmt.Sprintf("(%d) %s", len(r.body), string(r.body))
-	}
-	output = append(output, fmt.Sprintf("Body: %s", e))
+	output = append(output, fmt.Sprintf("Body: (%d) %s", elen, e))
 
 	return strings.Join(output, "\n")
 }

--- a/request.go
+++ b/request.go
@@ -1,16 +1,31 @@
 package httpmock
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 var (
 	ErrReturnStatusCode = errors.New("invalid return status code")
 	ErrWriteReturnBody  = errors.New("error writing return body")
+	ErrReadBody         = errors.New("error reading body")
 
 	AnyMethod = "mock.AnyMethod"
+
+	cmpoptCmpUnorderedSlices              = cmpopts.SortSlices(func(a, b string) bool { return a < b })
+	cmpoptIgnoreURLUnexportedStructFields = cmpopts.IgnoreUnexported(url.URL{})
+
+	fmtMissing  = "(Missing)"
+	fmtNotEqual = "!="
+	fmtEqual    = "=="
 )
 
 type Request struct {
@@ -22,14 +37,25 @@ type Request struct {
 	returnHeaders    *http.Header
 	returnBody       []byte
 
+	parent        *Mock
 	repeatability int
+	totalRequests int
 }
 
-func newRequest(method string, URL *url.URL) *Request {
+func newRequest(parent *Mock, method string, URL *url.URL) *Request {
 	return &Request{
 		method: method,
 		url:    URL,
+		parent: parent,
 	}
+}
+
+func (r *Request) lock() {
+	r.parent.mutex.Lock()
+}
+
+func (r *Request) unlock() {
+	r.parent.mutex.Unlock()
 }
 
 func (r *Request) Body(body []byte) *Request {
@@ -39,6 +65,9 @@ func (r *Request) Body(body []byte) *Request {
 }
 
 func (r *Request) QueryParam(param string, value string) *Request {
+	r.lock()
+	defer r.unlock()
+
 	values := r.url.Query()
 
 	values.Set(param, value)
@@ -48,24 +77,26 @@ func (r *Request) QueryParam(param string, value string) *Request {
 }
 
 func (r *Request) ReturnStatusCode(statusCode int) *Request {
+	r.lock()
+	defer r.unlock()
+
 	r.returnStatusCode = statusCode
 
 	return r
 }
 
 func (r *Request) ReturnStatusOK() *Request {
-	r.returnStatusCode = http.StatusOK
-
-	return r
+	return r.ReturnStatusCode(http.StatusOK)
 }
 
 func (r *Request) ReturnStatusNoContent() *Request {
-	r.returnStatusCode = http.StatusNoContent
-
-	return r
+	return r.ReturnStatusCode(http.StatusNoContent)
 }
 
 func (r *Request) ReturnHeaders(header string, value string) *Request {
+	r.lock()
+	defer r.unlock()
+
 	if r.returnHeaders == nil {
 		r.returnHeaders = &http.Header{}
 	}
@@ -76,12 +107,18 @@ func (r *Request) ReturnHeaders(header string, value string) *Request {
 }
 
 func (r *Request) ReturnBody(body []byte) *Request {
+	r.lock()
+	defer r.unlock()
+
 	r.returnBody = body
 
 	return r
 }
 
 func (r *Request) WriteResponse(w http.ResponseWriter) error {
+	r.lock()
+	defer r.unlock()
+
 	if r.returnStatusCode == 0 {
 		return ErrReturnStatusCode
 	}
@@ -115,6 +152,302 @@ func (r *Request) Twice() *Request {
 }
 
 func (r *Request) Times(i int) *Request {
+	r.lock()
+	defer r.unlock()
+
 	r.repeatability = i
 	return r
+}
+
+func (r *Request) On(method string, path string) *Request {
+	return r.parent.On(method, path)
+}
+
+func diffMissing(v string) (string, bool) {
+	if v == "" {
+		return fmtMissing, false
+	}
+	return v, true
+}
+
+func (r *Request) diffMethod(other *http.Request) (string, int) {
+	var output string
+	var differences int
+
+	expected := r.method
+	if r.method == "" {
+		expected = fmtMissing
+	} else if r.method == AnyMethod {
+		expected = "(AnyMethod)"
+	}
+
+	actual := other.Method
+	if other.Method == "" {
+		actual = fmtMissing
+	}
+
+	if (r.method == AnyMethod && other.Method != "") || ((r.method == other.Method) && (r.method != "")) {
+		output = fmt.Sprintf("\t%d: PASS:  %s == %s\n", 0, actual, expected)
+	} else {
+		output = fmt.Sprintf("\t%d: FAIL:  %s != %s\n", 0, actual, expected)
+		differences++
+	}
+
+	return output, differences
+}
+
+// Query logic:
+// - if request query is empty, don't compare queries
+// - if request query is not empty, only compare keys found in request query
+func (r *Request) diffQuery(other *http.Request) (string, int) {
+	var output string
+	var differences int
+
+	rQuery := r.url.Query()
+	if len(rQuery) == 0 {
+		return output, differences
+	}
+
+	oQuery := other.URL.Query()
+	oFilteredQuery := url.Values{}
+	for k := range rQuery {
+		if v, ok := oQuery[k]; ok {
+			oFilteredQuery[k] = v
+		}
+	}
+
+	e, _ := diffMissing(rQuery.Encode())
+
+	a, aok := diffMissing(oFilteredQuery.Encode())
+	a2, a2ok := diffMissing(oQuery.Encode())
+	if !aok && !a2ok {
+		// No filtered-query or full-query available
+		a2 = ""
+	} else if !aok && a2ok {
+		// No filtered-query available
+		a2 = fmt.Sprintf(" ((%s))", a2)
+	} else {
+		// Filtered-query and full-query both available
+		a2 = fmt.Sprintf(" (%s)", a2)
+	}
+	a = fmt.Sprintf("%s%s", a, a2)
+
+	eq := fmtEqual
+	if !cmp.Equal(rQuery, oFilteredQuery, cmpoptCmpUnorderedSlices) {
+		eq = fmtNotEqual
+		differences++
+	}
+
+	output = fmt.Sprintf("\t\t     Query:  %s %s %s\n", a, eq, e)
+
+	return output, differences
+}
+
+func (r *Request) diffURL(other *http.Request) (string, int) {
+	var output string
+	var differences int
+
+	expected, eok := diffMissing(r.url.String())
+	actual, aok := diffMissing(other.URL.String())
+	if !eok || !aok {
+		output = fmt.Sprintf("\t%d: FAIL:  %s == %s\n", 1, actual, expected)
+		differences++
+		return output, differences
+	}
+
+	var schemeFmt, hostFmt, pathFmt, queryFmt, fragmentFmt string
+
+	e, eok := diffMissing(r.url.Scheme)
+	a, aok := diffMissing(other.URL.Scheme)
+	if eok || aok {
+		eq := fmtNotEqual
+		if cmp.Equal(r.url.Scheme, other.URL.Scheme) {
+			eq = fmtEqual
+		}
+		schemeFmt = fmt.Sprintf("\t\t    Scheme:  %s %s %s\n", a, eq, e)
+	}
+
+	e, eok = diffMissing(r.url.Host)
+	a, aok = diffMissing(other.URL.Host)
+	if eok || aok {
+		eq := fmtNotEqual
+		if cmp.Equal(r.url.Host, other.URL.Host) {
+			eq = fmtEqual
+		}
+		hostFmt = fmt.Sprintf("\t\t      Host:  %s %s %s\n", a, eq, e)
+	}
+
+	e, eok = diffMissing(r.url.Path)
+	a, aok = diffMissing(other.URL.Path)
+	if eok || aok {
+		eq := fmtNotEqual
+		if cmp.Equal(r.url.Path, other.URL.Path) {
+			eq = fmtEqual
+		}
+		pathFmt = fmt.Sprintf("\t\t      Path:  %s %s %s\n", a, eq, e)
+	}
+
+	queryFmt, queryDifferences := r.diffQuery(other)
+
+	e, eok = diffMissing(r.url.Fragment)
+	a, aok = diffMissing(other.URL.Fragment)
+	if eok || aok {
+		eq := fmtNotEqual
+		if cmp.Equal(r.url.Fragment, other.URL.Fragment) {
+			eq = fmtEqual
+		}
+		fragmentFmt = fmt.Sprintf("\t\t  Fragment:  %s %s %s\n", a, eq, e)
+	}
+
+	ignoreURLQueryParams := cmpopts.IgnoreFields(url.URL{}, "RawQuery")
+	if cmp.Equal(*r.url, *other.URL, ignoreURLQueryParams, cmpoptIgnoreURLUnexportedStructFields) && queryDifferences == 0 {
+		output = fmt.Sprintf("\t%d: PASS:  %s == %s\n", 1, other.URL.String(), r.url.String())
+		output += schemeFmt
+		output += hostFmt
+		output += pathFmt
+		output += queryFmt
+		output += fragmentFmt
+	} else {
+		output = fmt.Sprintf("\t%d: FAIL:  %s == %s\n", 1, other.URL.String(), r.url.String())
+		output += schemeFmt
+		output += hostFmt
+		output += pathFmt
+		output += queryFmt
+		output += fragmentFmt
+
+		differences++
+	}
+
+	return output, differences
+}
+
+func readHTTPRequestBody(r *http.Request) ([]byte, error) {
+	// Read request body and reset it for the next comparison
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, ErrReadBody
+	}
+	r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	return body, nil
+}
+
+func (r *Request) diffBody(other *http.Request) (string, int) {
+	var output string
+	var differences int
+
+	// Read request body and reset it for the next comparison
+	otherBody, err := readHTTPRequestBody(other)
+	if err != nil {
+		return err.Error(), 1
+	}
+
+	e := fmtMissing
+	elen := len(r.body)
+	if elen > 1024 {
+		e = fmt.Sprintf("%s...", string(r.body[:1024]))
+	} else if elen > 0 {
+		e = string(r.body)
+	}
+	a := fmtMissing
+	alen := len(otherBody)
+	if alen > 1024 {
+		a = fmt.Sprintf("%s...", string(otherBody[:1024]))
+	} else if alen > 0 {
+		a = string(otherBody)
+	}
+	eq := fmtEqual
+	if elen == 0 && alen == 0 {
+		output = fmt.Sprintf("\t%d: PASS:  (0) %s == (0) %s\n", 2, e, a)
+		return output, differences
+	} else if (elen == 0 && alen > 0) || (elen > 0 && alen == 0) || !cmp.Equal(string(r.body), string(otherBody)) {
+		output = fmt.Sprintf("\t%d: FAIL:\n", 2)
+		eq = fmtNotEqual
+		differences++
+	} else {
+		output = fmt.Sprintf("\t%d: PASS:\n", 2)
+	}
+	output = fmt.Sprintf("%s\t\t (%d) %s\n\n\t\t    %s\n\n\t\t (%d) %s\n", output, elen, e, eq, alen, a)
+
+	return output, differences
+}
+
+func (r *Request) diff(other *http.Request) (string, int) {
+	output := "\n"
+	var differences int
+
+	o, d := r.diffMethod(other)
+	output += o
+	differences += d
+
+	o, d = r.diffURL(other)
+	output += o
+	differences += d
+
+	o, d = r.diffBody(other)
+	output += o
+	differences += d
+
+	return output, differences
+}
+
+func (r *Request) String() string {
+	var output []string
+
+	e := r.method
+	if r.method == "" {
+		e = fmtMissing
+	} else if r.method == AnyMethod {
+		e = "(AnyMethod)"
+	}
+	output = append(output, fmt.Sprintf("Method: %s", e))
+
+	e = r.url.String()
+	if e == "" {
+		output = append(output, fmt.Sprintf("URL: %s", fmtMissing))
+		return strings.Join(output, "\n")
+	}
+	output = append(output, fmt.Sprintf("URL: %s", e))
+
+	e, eok := diffMissing(r.url.Scheme)
+	if !eok {
+		e = fmtMissing
+	}
+	output = append(output, fmt.Sprintf("\tScheme: %s", e))
+
+	e, eok = diffMissing(r.url.Host)
+	if !eok {
+		e = fmtMissing
+	}
+	output = append(output, fmt.Sprintf("\tHost: %s", e))
+
+	e, eok = diffMissing(r.url.Path)
+	if !eok {
+		e = fmtMissing
+	}
+	output = append(output, fmt.Sprintf("\tPath: %s", e))
+
+	e, eok = diffMissing(r.url.RawQuery)
+	if !eok {
+		e = fmtMissing
+	}
+	output = append(output, fmt.Sprintf("\tQuery: %s", e))
+
+	e, eok = diffMissing(r.url.Fragment)
+	if !eok {
+		e = fmtMissing
+	}
+	output = append(output, fmt.Sprintf("\tFragment: %s", e))
+
+	e = fmtMissing
+	elen := len(r.body)
+	if elen > 1024 {
+		e = fmt.Sprintf("%s...", string(r.body[:1024]))
+	} else if elen > 0 {
+		e = string(r.body)
+	}
+	output = append(output, fmt.Sprintf("Body: %s", e))
+
+	return strings.Join(output, "\n")
 }

--- a/request.go
+++ b/request.go
@@ -261,7 +261,7 @@ func readHTTPRequestBody(r *http.Request) ([]byte, error) {
 	// Read request body and reset it for the next comparison
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		return nil, ErrReadBody
+		return nil, fmt.Errorf("%w: %v", ErrReadBody, err)
 	}
 	r.Body.Close()
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
@@ -339,49 +339,48 @@ func (r *Request) String() string {
 	}
 	output = append(output, fmt.Sprintf("Method: %s", e))
 
-	e = r.url.String()
-	if e == "" {
+	if e = r.url.String(); e == "" {
 		output = append(output, fmt.Sprintf("URL: %s", fmtMissing))
-		return strings.Join(output, "\n")
-	}
-	output = append(output, fmt.Sprintf("URL: %s", e))
+	} else {
+		output = append(output, fmt.Sprintf("URL: %s", e))
 
-	e, eok := diffMissing(r.url.Scheme)
-	if !eok {
-		e = fmtMissing
-	}
-	output = append(output, fmt.Sprintf("\tScheme: %s", e))
+		e, eok := diffMissing(r.url.Scheme)
+		if !eok {
+			e = fmtMissing
+		}
+		output = append(output, fmt.Sprintf("\tScheme: %s", e))
 
-	e, eok = diffMissing(r.url.Host)
-	if !eok {
-		e = fmtMissing
-	}
-	output = append(output, fmt.Sprintf("\tHost: %s", e))
+		e, eok = diffMissing(r.url.Host)
+		if !eok {
+			e = fmtMissing
+		}
+		output = append(output, fmt.Sprintf("\tHost: %s", e))
 
-	e, eok = diffMissing(r.url.Path)
-	if !eok {
-		e = fmtMissing
-	}
-	output = append(output, fmt.Sprintf("\tPath: %s", e))
+		e, eok = diffMissing(r.url.Path)
+		if !eok {
+			e = fmtMissing
+		}
+		output = append(output, fmt.Sprintf("\tPath: %s", e))
 
-	e, eok = diffMissing(r.url.RawQuery)
-	if !eok {
-		e = fmtMissing
-	}
-	output = append(output, fmt.Sprintf("\tQuery: %s", e))
+		e, eok = diffMissing(r.url.RawQuery)
+		if !eok {
+			e = fmtMissing
+		}
+		output = append(output, fmt.Sprintf("\tQuery: %s", e))
 
-	e, eok = diffMissing(r.url.Fragment)
-	if !eok {
-		e = fmtMissing
+		e, eok = diffMissing(r.url.Fragment)
+		if !eok {
+			e = fmtMissing
+		}
+		output = append(output, fmt.Sprintf("\tFragment: %s", e))
 	}
-	output = append(output, fmt.Sprintf("\tFragment: %s", e))
 
 	e = fmtMissing
 	elen := len(r.body)
 	if elen > 1024 {
-		e = fmt.Sprintf("%s...", string(r.body[:1024]))
+		e = fmt.Sprintf("(%d) %s...", len(r.body), string(r.body[:1024]))
 	} else if elen > 0 {
-		e = string(r.body)
+		e = fmt.Sprintf("(%d) %s", len(r.body), string(r.body))
 	}
 	output = append(output, fmt.Sprintf("Body: %s", e))
 

--- a/request.go
+++ b/request.go
@@ -29,6 +29,8 @@ var (
 )
 
 type Request struct {
+	parent *Mock
+
 	method string
 	url    *url.URL
 	body   []byte
@@ -37,16 +39,16 @@ type Request struct {
 	returnHeaders    *http.Header
 	returnBody       []byte
 
-	parent        *Mock
 	repeatability int
 	totalRequests int
 }
 
-func newRequest(parent *Mock, method string, URL *url.URL) *Request {
+func newRequest(parent *Mock, method string, URL *url.URL, body []byte) *Request {
 	return &Request{
+		parent: parent,
 		method: method,
 		url:    URL,
-		parent: parent,
+		body:   body,
 	}
 }
 
@@ -56,12 +58,6 @@ func (r *Request) lock() {
 
 func (r *Request) unlock() {
 	r.parent.mutex.Unlock()
-}
-
-func (r *Request) Body(body []byte) *Request {
-	r.body = body
-
-	return r
 }
 
 func (r *Request) QueryParam(param string, value string) *Request {
@@ -159,8 +155,8 @@ func (r *Request) Times(i int) *Request {
 	return r
 }
 
-func (r *Request) On(method string, path string) *Request {
-	return r.parent.On(method, path)
+func (r *Request) On(method string, path string, body []byte) *Request {
+	return r.parent.On(method, path, body)
 }
 
 func diffMissing(v string) (string, bool) {

--- a/request.go
+++ b/request.go
@@ -21,6 +21,8 @@ type Request struct {
 	returnStatusCode int
 	returnHeaders    *http.Header
 	returnBody       []byte
+
+	repeatability int
 }
 
 func newRequest(method string, URL *url.URL) *Request {
@@ -102,4 +104,17 @@ func (r *Request) WriteResponse(w http.ResponseWriter) error {
 	}
 
 	return nil
+}
+
+func (r *Request) Once() *Request {
+	return r.Times(1)
+}
+
+func (r *Request) Twice() *Request {
+	return r.Times(2)
+}
+
+func (r *Request) Times(i int) *Request {
+	r.repeatability = i
+	return r
 }

--- a/request_test.go
+++ b/request_test.go
@@ -402,3 +402,36 @@ func TestRequest_WriteResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestRequest_Times(t *testing.T) {
+	// Setup
+	r := Request{}
+
+	// Test
+	r.Times(4)
+
+	// Assertions
+	assert.Equal(t, 4, r.repeatability)
+}
+
+func TestRequest_Once(t *testing.T) {
+	// Setup
+	r := Request{}
+
+	// Test
+	r.Once()
+
+	// Assertions
+	assert.Equal(t, 1, r.repeatability)
+}
+
+func TestRequest_Twice(t *testing.T) {
+	// Setup
+	r := Request{}
+
+	// Test
+	r.Twice()
+
+	// Assertions
+	assert.Equal(t, 2, r.repeatability)
+}

--- a/request_test.go
+++ b/request_test.go
@@ -768,7 +768,7 @@ func TestRequest_String(t *testing.T) {
 			want: `
 Method: (Missing)
 URL: (Missing)
-Body: (Missing)`,
+Body: (0) (Missing)`,
 		},
 		{
 			name: "missing-method",
@@ -957,7 +957,7 @@ URL: https://test.com/foo?limit=1#back
 	Path: /foo
 	Query: limit=1
 	Fragment: back
-Body: (Missing)`,
+Body: (0) (Missing)`,
 		},
 		{
 			name: "missing-body",

--- a/request_test.go
+++ b/request_test.go
@@ -209,23 +209,6 @@ func TestRequest_RespondNoContent(t *testing.T) {
 	assert.Equal(t, got, r.response)
 }
 
-func TestRequest_On(t *testing.T) {
-	// Setup
-	m := new(Mock)
-	r := m.On(http.MethodGet, "test.com/foo/1234", nil)
-
-	// Test
-	got := r.On(http.MethodPut, "test.com/foo", []byte(`{"foo": "bar"}`))
-
-	// Assertions
-	assert.NotNil(t, got)
-	wantExpectedRequests := []*Request{
-		r,
-		got,
-	}
-	assert.Equal(t, wantExpectedRequests, m.ExpectedRequests)
-}
-
 func TestRequest_Times(t *testing.T) {
 	// Setup
 	r := Request{parent: new(Mock)}

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,404 @@
+package httpmock
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type constraintFunc func(r *Request) *Request
+
+func TestRequest_Modifiers(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		url         string
+		constraints []constraintFunc
+		want        *Request
+	}{
+		{
+			name:   "no-constraints",
+			method: http.MethodGet,
+			url:    "https://test.com/foo",
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+			},
+		},
+		{
+			name:   "method",
+			method: http.MethodPut,
+			url:    "https://test.com/foo",
+			want: &Request{
+				method: "PUT",
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+			},
+		},
+		{
+			name:   "any-method",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+			},
+		},
+		{
+			name:   "body",
+			method: http.MethodGet,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.Body([]byte("Hello World!")) },
+			},
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				body: []byte("Hello World!"),
+			},
+		},
+		{
+			name:   "body-repeat-call",
+			method: http.MethodGet,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.Body([]byte("Hello World!")) },
+				func(r *Request) *Request { return r.Body([]byte("Hi there!")) },
+			},
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				body: []byte("Hi there!"),
+			},
+		},
+		{
+			name:   "query-param-first",
+			method: http.MethodGet,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.QueryParam("limit", "1234") },
+			},
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme:   "https",
+					Host:     "test.com",
+					Path:     "/foo",
+					RawQuery: "limit=1234",
+				},
+			},
+		},
+		{
+			name:   "query-param-repeat-call",
+			method: http.MethodGet,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.QueryParam("limit", "1234") },
+				func(r *Request) *Request { return r.QueryParam("limit", "5678") },
+			},
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme:   "https",
+					Host:     "test.com",
+					Path:     "/foo",
+					RawQuery: "limit=5678",
+				},
+			},
+		},
+		{
+			name:   "query-param",
+			method: http.MethodGet,
+			url:    "https://test.com/foo?next=aaa21242&count=2",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.QueryParam("limit", "1234") },
+				func(r *Request) *Request { return r.QueryParam("next", "aaa21242") },
+			},
+			want: &Request{
+				method: "GET",
+				url: &url.URL{
+					Scheme:   "https",
+					Host:     "test.com",
+					Path:     "/foo",
+					RawQuery: "next=aaa21242&count=2&limit=1234",
+				},
+			},
+		},
+		{
+			name:   "return-status-code",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnStatusCode(http.StatusForbidden) },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnStatusCode: 403,
+			},
+		},
+		{
+			name:   "return-status-ok",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnStatusOK() },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnStatusCode: 200,
+			},
+		},
+		{
+			name:   "return-status-no-content",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnStatusNoContent() },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnStatusCode: 204,
+			},
+		},
+		{
+			name:   "return-headers-nil",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnHeaders: &http.Header{
+					"Content-Length": []string{"5"},
+				},
+			},
+		},
+		{
+			name:   "return-headers",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Type", "application/json") },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnHeaders: &http.Header{
+					"Content-Length": []string{"5"},
+					"Content-Type":   []string{"application/json"},
+				},
+			},
+		},
+		{
+			name:   "return-headers-overwrite",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "7") },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnHeaders: &http.Header{
+					"Content-Length": []string{"7"},
+				},
+			},
+		},
+		{
+			name:   "return-body",
+			method: AnyMethod,
+			url:    "https://test.com/foo",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+			},
+			want: &Request{
+				method: AnyMethod,
+				url: &url.URL{
+					Scheme: "https",
+					Host:   "test.com",
+					Path:   "/foo",
+				},
+				returnBody: []byte("Hello World!"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			url, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected failure to parse test url: %v", err)
+			}
+
+			got := newRequest(tt.method, url)
+
+			// Test
+			for _, constraint := range tt.constraints {
+				got = constraint(got)
+			}
+
+			// Assertions
+			gotQuery := got.url.Query()
+			got.url.RawQuery = ""
+			wantQuery := tt.want.url.Query()
+			tt.want.url.RawQuery = ""
+			assert.Equal(t, wantQuery, gotQuery)
+			assert.Equal(t, tt.want, got)
+
+		})
+	}
+}
+
+func TestRequest_WriteResponse_MissingStatusCode(t *testing.T) {
+	// Setup
+	url, err := url.Parse("https://test.com/foo")
+	if err != nil {
+		t.Fatalf("unexpected failure to parse test url: %v", err)
+	}
+
+	r := newRequest(AnyMethod, url)
+
+	mockResponseWriter := httptest.NewRecorder()
+
+	// Test
+	gotErr := r.WriteResponse(mockResponseWriter)
+
+	// Assertions
+	assert.ErrorIs(t, gotErr, ErrReturnStatusCode)
+}
+
+func TestRequest_WriteResponse(t *testing.T) {
+	url, err := url.Parse("https://test.com/foo")
+	if err != nil {
+		t.Fatalf("unexpected failure to parse test url: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		constraints []constraintFunc
+		wantHeaders http.Header
+		wantBody    []byte
+	}{
+		{
+			name:        "no-headers-no-body",
+			wantHeaders: http.Header{},
+			wantBody:    []byte(""),
+		},
+		{
+			name: "headers-no-body",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Type", "text/plain; charset=utf-8") },
+			},
+			wantHeaders: http.Header{
+				"Content-Length": []string{"5"},
+				"Content-Type":   []string{"text/plain; charset=utf-8"},
+			},
+			wantBody: []byte(""),
+		},
+		{
+			name: "no-headers-body",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+			},
+			wantHeaders: http.Header{},
+			wantBody:    []byte("Hello World!"),
+		},
+		{
+			name: "headers-and-body",
+			constraints: []constraintFunc{
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
+				func(r *Request) *Request { return r.ReturnHeaders("Content-Type", "text/plain; charset=utf-8") },
+				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+			},
+			wantHeaders: http.Header{
+				"Content-Length": []string{"5"},
+				"Content-Type":   []string{"text/plain; charset=utf-8"},
+			},
+			wantBody: []byte("Hello World!"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			r := newRequest(AnyMethod, url).ReturnStatusOK()
+			for _, constraint := range tt.constraints {
+				r = constraint(r)
+			}
+
+			mockResponseWriter := httptest.NewRecorder()
+
+			// Test
+			r.WriteResponse(mockResponseWriter)
+
+			got := mockResponseWriter.Result()
+
+			gotBody, err := io.ReadAll(got.Body)
+			if err != nil {
+				t.Fatalf("unexpected error reading response body: %v", err)
+			}
+			defer got.Body.Close()
+
+			// Assertions
+			assert.Equal(t, http.StatusOK, got.StatusCode)
+			assert.Equal(t, tt.wantHeaders, got.Header)
+			assert.Equal(t, tt.wantBody, gotBody)
+		})
+	}
+}

--- a/request_test.go
+++ b/request_test.go
@@ -24,6 +24,7 @@ func TestRequest_Modifiers(t *testing.T) {
 		name        string
 		method      string
 		url         string
+		body        []byte
 		constraints []constraintFunc
 		want        *Request
 	}{
@@ -70,9 +71,7 @@ func TestRequest_Modifiers(t *testing.T) {
 			name:   "body",
 			method: http.MethodGet,
 			url:    "https://test.com/foo",
-			constraints: []constraintFunc{
-				func(r *Request) *Request { return r.Body([]byte("Hello World!")) },
-			},
+			body:   []byte(`Hello World!`),
 			want: &Request{
 				method: "GET",
 				url: &url.URL{
@@ -80,25 +79,7 @@ func TestRequest_Modifiers(t *testing.T) {
 					Host:   "test.com",
 					Path:   "/foo",
 				},
-				body: []byte("Hello World!"),
-			},
-		},
-		{
-			name:   "body-repeat-call",
-			method: http.MethodGet,
-			url:    "https://test.com/foo",
-			constraints: []constraintFunc{
-				func(r *Request) *Request { return r.Body([]byte("Hello World!")) },
-				func(r *Request) *Request { return r.Body([]byte("Hi there!")) },
-			},
-			want: &Request{
-				method: "GET",
-				url: &url.URL{
-					Scheme: "https",
-					Host:   "test.com",
-					Path:   "/foo",
-				},
-				body: []byte("Hi there!"),
+				body: []byte(`Hello World!`),
 			},
 		},
 		{
@@ -270,7 +251,7 @@ func TestRequest_Modifiers(t *testing.T) {
 			method: AnyMethod,
 			url:    "https://test.com/foo",
 			constraints: []constraintFunc{
-				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+				func(r *Request) *Request { return r.ReturnBody([]byte(`Hello World!`)) },
 			},
 			want: &Request{
 				method: AnyMethod,
@@ -279,7 +260,7 @@ func TestRequest_Modifiers(t *testing.T) {
 					Host:   "test.com",
 					Path:   "/foo",
 				},
-				returnBody: []byte("Hello World!"),
+				returnBody: []byte(`Hello World!`),
 			},
 		},
 	}
@@ -294,7 +275,7 @@ func TestRequest_Modifiers(t *testing.T) {
 				t.Fatalf("unexpected failure to parse test url: %v", err)
 			}
 
-			got := newRequest(m, tt.method, url)
+			got := newRequest(m, tt.method, url, tt.body)
 
 			// Test
 			for _, constraint := range tt.constraints {
@@ -344,7 +325,7 @@ func TestRequest_WriteResponse(t *testing.T) {
 		{
 			name:        "no-headers-no-body",
 			wantHeaders: http.Header{},
-			wantBody:    []byte(""),
+			wantBody:    []byte(``),
 		},
 		{
 			name: "headers-no-body",
@@ -356,28 +337,28 @@ func TestRequest_WriteResponse(t *testing.T) {
 				"Content-Length": []string{"5"},
 				"Content-Type":   []string{"text/plain; charset=utf-8"},
 			},
-			wantBody: []byte(""),
+			wantBody: []byte(``),
 		},
 		{
 			name: "no-headers-body",
 			constraints: []constraintFunc{
-				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+				func(r *Request) *Request { return r.ReturnBody([]byte(`Hello World!`)) },
 			},
 			wantHeaders: http.Header{},
-			wantBody:    []byte("Hello World!"),
+			wantBody:    []byte(`Hello World!`),
 		},
 		{
 			name: "headers-and-body",
 			constraints: []constraintFunc{
 				func(r *Request) *Request { return r.ReturnHeaders("Content-Length", "5") },
 				func(r *Request) *Request { return r.ReturnHeaders("Content-Type", "text/plain; charset=utf-8") },
-				func(r *Request) *Request { return r.ReturnBody([]byte("Hello World!")) },
+				func(r *Request) *Request { return r.ReturnBody([]byte(`Hello World!`)) },
 			},
 			wantHeaders: http.Header{
 				"Content-Length": []string{"5"},
 				"Content-Type":   []string{"text/plain; charset=utf-8"},
 			},
-			wantBody: []byte("Hello World!"),
+			wantBody: []byte(`Hello World!`),
 		},
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -31,6 +31,7 @@ ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 Now I am too long
 `)
 
+// badReader implements the io.Reader interface, but always fails to read.
 type badReader struct{}
 
 func (br *badReader) Read(_ []byte) (n int, err error) {

--- a/response.go
+++ b/response.go
@@ -41,16 +41,20 @@ func (r *Response) Header(key string, value string, values ...string) *Response 
 	return r
 }
 
-func (r *Response) Times(i int) *Request {
-	return r.parent.Times(i)
-}
-
 func (r *Response) Once() *Request {
 	return r.parent.Once()
 }
 
 func (r *Response) Twice() *Request {
 	return r.parent.Twice()
+}
+
+func (r *Response) Times(i int) *Request {
+	return r.parent.Times(i)
+}
+
+func (r *Response) On(method string, path string, body []byte) *Request {
+	return r.parent.parent.On(method, path, body)
 }
 
 func (r *Response) Write(w http.ResponseWriter) (int, error) {

--- a/response.go
+++ b/response.go
@@ -7,12 +7,18 @@ import (
 
 var ErrWriteReturnBody = errors.New("error writing return body")
 
+// Response hold the parts of the response that should be returned.
 type Response struct {
 	parent *Request
 
+	// The HTTP status code that should be used in a response.
 	statusCode int
-	header     http.Header
-	body       []byte
+
+	// Headers that should be used in a response.
+	header http.Header
+
+	// Body that should be used in a response.
+	body []byte
 }
 
 func newResponse(parent *Request, statusCode int, body []byte) *Response {
@@ -24,14 +30,18 @@ func newResponse(parent *Request, statusCode int, body []byte) *Response {
 	}
 }
 
+// lock is a convenience method to lock the grandparent mock's mutex.
 func (r *Response) lock() {
 	r.parent.parent.mutex.Lock()
 }
 
+// unlock is a convenience method to unlock the grandparent mock's mutex.
 func (r *Response) unlock() {
 	r.parent.parent.mutex.Unlock()
 }
 
+// Header sets the value or values for a response header. Any prior values that
+// have already been set for a header with the same key will be overridden.
 func (r *Response) Header(key string, value string, values ...string) *Response {
 	r.lock()
 	defer r.unlock()
@@ -41,22 +51,44 @@ func (r *Response) Header(key string, value string, values ...string) *Response 
 	return r
 }
 
+// Once is a convenience method which indicates that the grandparent mock
+// should only return the parent's response once.
+//
+//	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Once()
 func (r *Response) Once() *Request {
 	return r.parent.Once()
 }
 
+// Twice is a convenience method which indicates that the grandparent mock
+// should only return the parent's response twice.
+//
+//	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Twice()
 func (r *Response) Twice() *Request {
 	return r.parent.Twice()
 }
 
+// Times is a convenience method which indicates that the grandparent mock
+// should only return the indicated number of times.
+//
+//	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Times(5)
 func (r *Response) Times(i int) *Request {
 	return r.parent.Times(i)
 }
 
+// On chains a new expectation description onto the grandparent mock. This
+// allows syntax like:
+//
+//	Mock.
+//		On(http.MethodPost, "/some/path").RespondOk([]byte(`{"id": "1234"}`)).
+//		On(http.MethodDelete, "/some/path/1234").RespondNoContent().
+//		On(http.MethodDelete, "/some/path/1234").Respond(http.StatusNotFound, nil)
 func (r *Response) On(method string, path string, body []byte) *Request {
 	return r.parent.parent.On(method, path, body)
 }
 
+// Write the response to the provided http.ResponseWriter. The number of bytes
+// successfully written to the http.ResponseWriter are returned, as well as any
+// errors.
 func (r *Response) Write(w http.ResponseWriter) (int, error) {
 	r.lock()
 	defer r.unlock()

--- a/response.go
+++ b/response.go
@@ -1,0 +1,76 @@
+package httpmock
+
+import (
+	"errors"
+	"net/http"
+)
+
+var ErrWriteReturnBody = errors.New("error writing return body")
+
+type Response struct {
+	parent *Request
+
+	statusCode int
+	header     http.Header
+	body       []byte
+}
+
+func newResponse(parent *Request, statusCode int, body []byte) *Response {
+	return &Response{
+		parent:     parent,
+		statusCode: statusCode,
+		header:     http.Header{},
+		body:       body,
+	}
+}
+
+func (r *Response) lock() {
+	r.parent.parent.mutex.Lock()
+}
+
+func (r *Response) unlock() {
+	r.parent.parent.mutex.Unlock()
+}
+
+func (r *Response) Header(key string, value string, values ...string) *Response {
+	r.lock()
+	defer r.unlock()
+
+	v := append(r.header[key], value)
+	r.header[key] = append(v, values...)
+	return r
+}
+
+func (r *Response) Times(i int) *Request {
+	return r.parent.Times(i)
+}
+
+func (r *Response) Once() *Request {
+	return r.parent.Once()
+}
+
+func (r *Response) Twice() *Request {
+	return r.parent.Twice()
+}
+
+func (r *Response) Write(w http.ResponseWriter) (int, error) {
+	r.lock()
+	defer r.unlock()
+
+	h := w.Header()
+	for key, values := range r.header {
+		h[key] = values
+	}
+
+	w.WriteHeader(r.statusCode)
+
+	if r.body != nil {
+		n, err := w.Write(r.body)
+		if err != nil {
+			return n, ErrWriteReturnBody
+		}
+		return n, nil
+	}
+
+	return 0, nil
+}

--- a/response.go
+++ b/response.go
@@ -52,7 +52,7 @@ func (r *Response) Header(key string, value string, values ...string) *Response 
 }
 
 // Once is a convenience method which indicates that the grandparent mock
-// should only return the parent's response once.
+// should only expect the parent request once.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Once()
 func (r *Response) Once() *Request {
@@ -60,7 +60,7 @@ func (r *Response) Once() *Request {
 }
 
 // Twice is a convenience method which indicates that the grandparent mock
-// should only return the parent's response twice.
+// should only expect the parent request twice.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Twice()
 func (r *Response) Twice() *Request {
@@ -68,7 +68,7 @@ func (r *Response) Twice() *Request {
 }
 
 // Times is a convenience method which indicates that the grandparent mock
-// should only return the indicated number of times.
+// should only expect the parent request the indicated number of times.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Times(5)
 func (r *Response) Times(i int) *Request {

--- a/response_test.go
+++ b/response_test.go
@@ -84,86 +84,86 @@ func TestResponse_Header(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			req := &Request{parent: new(Mock).Test(t)}
-			resp := newResponse(
-				req,
+			expected := &Request{parent: new(Mock).Test(t)}
+			response := newResponse(
+				expected,
 				http.StatusTemporaryRedirect,
 				nil,
 			)
 
 			// Test
-			resp = tt.headerFunc(resp)
+			response = tt.headerFunc(response)
 
 			// Assertions
-			tt.want.parent = req
-			assert.Equal(t, tt.want, resp)
+			tt.want.parent = expected
+			assert.Equal(t, tt.want, response)
 		})
 	}
 }
 
 func TestResponse_Once(t *testing.T) {
 	// Setup
-	req := &Request{parent: new(Mock).Test(t)}
-	resp := Response{parent: req}
+	expected := &Request{parent: new(Mock).Test(t)}
+	response := Response{parent: expected}
 
 	// Test
-	resp.Once()
+	response.Once()
 
 	// Assertions
-	assert.Equal(t, 1, req.repeatability)
+	assert.Equal(t, 1, expected.repeatability)
 }
 
 func TestResponse_Twice(t *testing.T) {
 	// Setup
-	req := &Request{parent: new(Mock).Test(t)}
-	resp := Response{parent: req}
+	expected := &Request{parent: new(Mock).Test(t)}
+	response := Response{parent: expected}
 
 	// Test
-	resp.Twice()
+	response.Twice()
 
 	// Assertions
-	assert.Equal(t, 2, req.repeatability)
+	assert.Equal(t, 2, expected.repeatability)
 }
 
 func TestResponse_Times(t *testing.T) {
 	// Setup
-	req := &Request{parent: new(Mock).Test(t)}
-	resp := Response{parent: req}
+	expected := &Request{parent: new(Mock).Test(t)}
+	response := Response{parent: expected}
 
 	// Test
-	resp.Times(4)
+	response.Times(4)
 
 	// Assertions
-	assert.Equal(t, 4, req.repeatability)
+	assert.Equal(t, 4, expected.repeatability)
 }
 
 func TestResponse_On(t *testing.T) {
 	// Setup
-	r := &Response{
+	response := &Response{
 		parent:     &Request{parent: new(Mock).Test(t)},
 		statusCode: http.StatusOK,
-		body:       []byte(`Hello World!`),
+		body:       []byte(testBody),
 	}
 
 	// Test
-	got := r.On(http.MethodPut, "test.com/foo", []byte(`{"foo": "bar"}`))
+	got := response.On(http.MethodPut, "test.com/foo", []byte(`{"foo": "bar"}`))
 
 	// Assertions
 	assert.NotNil(t, got)
 	wantExpectedRequests := []*Request{got}
-	assert.Equal(t, wantExpectedRequests, r.parent.parent.ExpectedRequests)
+	assert.Equal(t, wantExpectedRequests, response.parent.parent.ExpectedRequests)
 }
 
 func TestResponse_Write_FailWriteBody(t *testing.T) {
 	// Setup
-	r := &Response{
+	response := &Response{
 		parent:     &Request{parent: new(Mock).Test(t)},
 		statusCode: http.StatusOK,
-		body:       []byte(`Hello World!`),
+		body:       []byte(testBody),
 	}
 
 	// Test
-	gotN, gotErr := r.Write(&badResponseWriter{})
+	gotN, gotErr := response.Write(&badResponseWriter{})
 
 	// Assertions
 	assert.Equal(t, -1, gotN)
@@ -191,22 +191,22 @@ func TestResponse_Write(t *testing.T) {
 			name: "ok-headers",
 			response: &Response{
 				statusCode: http.StatusOK,
-				body:       []byte(`Hello World!`),
+				body:       []byte(testBody),
 				header:     http.Header{"next": []string{"aaa21242"}},
 			},
 			wantStatusCode: http.StatusOK,
 			wantHeaders:    http.Header{"next": []string{"aaa21242"}},
-			wantBody:       []byte(`Hello World!`),
+			wantBody:       []byte(testBody),
 		},
 		{
 			name: "ok-body",
 			response: &Response{
 				statusCode: http.StatusOK,
-				body:       []byte(`Hello World!`),
+				body:       []byte(testBody),
 			},
 			wantStatusCode: http.StatusOK,
 			wantHeaders:    http.Header{},
-			wantBody:       []byte(`Hello World!`),
+			wantBody:       []byte(testBody),
 		},
 		{
 			name: "ok-headers-body",
@@ -216,14 +216,14 @@ func TestResponse_Write(t *testing.T) {
 					"X-Session-Id": []string{"1234"},
 					"X-Request-Id": []string{"5678"},
 				},
-				body: []byte(`Hello World!`),
+				body: []byte(testBody),
 			},
 			wantStatusCode: http.StatusOK,
 			wantHeaders: http.Header{
 				"X-Session-Id": []string{"1234"},
 				"X-Request-Id": []string{"5678"},
 			},
-			wantBody: []byte(`Hello World!`),
+			wantBody: []byte(testBody),
 		},
 		{
 			name: "bad-request",
@@ -247,16 +247,16 @@ func TestResponse_Write(t *testing.T) {
 			// Test
 			gotN, gotErr := tt.response.Write(recorder)
 
-			resp := recorder.Result()
-			gotBody, err := io.ReadAll(resp.Body)
+			response := recorder.Result()
+			gotBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				t.Fatalf("unexpected error reading test response body: %v", err)
 			}
 
 			// Assertions
 			assert.NoError(t, gotErr)
-			assert.Equal(t, tt.wantStatusCode, resp.StatusCode)
-			assert.Equal(t, tt.wantHeaders, resp.Header)
+			assert.Equal(t, tt.wantStatusCode, response.StatusCode)
+			assert.Equal(t, tt.wantHeaders, response.Header)
 			assert.Equal(t, len(tt.wantBody), gotN)
 			assert.Equal(t, tt.wantBody, gotBody)
 		})

--- a/response_test.go
+++ b/response_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// badResponseWriter implements the http.ResponseWriter interface, but always fails to write.
 type badResponseWriter struct{}
 
 func (brw *badResponseWriter) Header() http.Header               { return http.Header{} }

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,246 @@
+package httpmock
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type badResponseWriter struct{}
+
+func (brw *badResponseWriter) Header() http.Header               { return http.Header{} }
+func (brw *badResponseWriter) Write(_ []byte) (n int, err error) { return -1, io.ErrClosedPipe }
+func (brw *badResponseWriter) WriteHeader(statusCode int)        {}
+
+func TestResponse_Header(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerFunc func(r *Response) *Response
+		want       *Response
+	}{
+		{
+			name:       "no-header",
+			headerFunc: func(r *Response) *Response { return r },
+			want: &Response{
+				statusCode: http.StatusTemporaryRedirect,
+				header:     http.Header{},
+			},
+		},
+		{
+			name: "one-header-value",
+			headerFunc: func(r *Response) *Response {
+				return r.Header("foo", "bar")
+			},
+			want: &Response{
+				statusCode: http.StatusTemporaryRedirect,
+				header: http.Header{
+					"foo": []string{"bar"},
+				},
+			},
+		},
+		{
+			name: "multiple-header-values",
+			headerFunc: func(r *Response) *Response {
+				return r.Header("foo", "bar", "baz")
+			},
+			want: &Response{
+				statusCode: http.StatusTemporaryRedirect,
+				header: http.Header{
+					"foo": []string{"bar", "baz"},
+				},
+			},
+		},
+		{
+			name: "multiple-header-values-iter",
+			headerFunc: func(r *Response) *Response {
+				return r.Header("foo", "bar").Header("foo", "baz")
+			},
+			want: &Response{
+				statusCode: http.StatusTemporaryRedirect,
+				header: http.Header{
+					"foo": []string{"bar", "baz"},
+				},
+			},
+		},
+		{
+			name: "multiple-headers",
+			headerFunc: func(r *Response) *Response {
+				return r.Header("foo", "bar").Header("baz", "quz", "2")
+			},
+			want: &Response{
+				statusCode: http.StatusTemporaryRedirect,
+				header: http.Header{
+					"foo": []string{"bar"},
+					"baz": []string{"quz", "2"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			req := &Request{parent: new(Mock).Test(t)}
+			resp := newResponse(
+				req,
+				http.StatusTemporaryRedirect,
+				nil,
+			)
+
+			// Test
+			resp = tt.headerFunc(resp)
+
+			// Assertions
+			tt.want.parent = req
+			assert.Equal(t, tt.want, resp)
+		})
+	}
+}
+
+func TestResponse_Times(t *testing.T) {
+	// Setup
+	req := &Request{parent: new(Mock).Test(t)}
+	resp := Response{parent: req}
+
+	// Test
+	resp.Times(4)
+
+	// Assertions
+	assert.Equal(t, 4, req.repeatability)
+}
+
+func TestResponse_Once(t *testing.T) {
+	// Setup
+	req := &Request{parent: new(Mock).Test(t)}
+	resp := Response{parent: req}
+
+	// Test
+	resp.Once()
+
+	// Assertions
+	assert.Equal(t, 1, req.repeatability)
+}
+
+func TestResponse_Twice(t *testing.T) {
+	// Setup
+	req := &Request{parent: new(Mock).Test(t)}
+	resp := Response{parent: req}
+
+	// Test
+	resp.Twice()
+
+	// Assertions
+	assert.Equal(t, 2, req.repeatability)
+}
+
+func TestResponse_Write_FailWriteBody(t *testing.T) {
+	// Setup
+	r := &Response{
+		parent:     &Request{parent: new(Mock).Test(t)},
+		statusCode: http.StatusOK,
+		body:       []byte(`Hello World!`),
+	}
+
+	// Test
+	gotN, gotErr := r.Write(&badResponseWriter{})
+
+	// Assertions
+	assert.Equal(t, -1, gotN)
+	assert.ErrorIs(t, gotErr, ErrWriteReturnBody)
+}
+
+func TestResponse_Write(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       *Response
+		wantStatusCode int
+		wantHeaders    http.Header
+		wantBody       []byte
+	}{
+		{
+			name: "ok",
+			response: &Response{
+				statusCode: http.StatusOK,
+			},
+			wantStatusCode: http.StatusOK,
+			wantHeaders:    http.Header{},
+			wantBody:       []byte(``),
+		},
+		{
+			name: "ok-headers",
+			response: &Response{
+				statusCode: http.StatusOK,
+				body:       []byte(`Hello World!`),
+				header:     http.Header{"next": []string{"aaa21242"}},
+			},
+			wantStatusCode: http.StatusOK,
+			wantHeaders:    http.Header{"next": []string{"aaa21242"}},
+			wantBody:       []byte(`Hello World!`),
+		},
+		{
+			name: "ok-body",
+			response: &Response{
+				statusCode: http.StatusOK,
+				body:       []byte(`Hello World!`),
+			},
+			wantStatusCode: http.StatusOK,
+			wantHeaders:    http.Header{},
+			wantBody:       []byte(`Hello World!`),
+		},
+		{
+			name: "ok-headers-body",
+			response: &Response{
+				statusCode: http.StatusOK,
+				header: http.Header{
+					"X-Session-Id": []string{"1234"},
+					"X-Request-Id": []string{"5678"},
+				},
+				body: []byte(`Hello World!`),
+			},
+			wantStatusCode: http.StatusOK,
+			wantHeaders: http.Header{
+				"X-Session-Id": []string{"1234"},
+				"X-Request-Id": []string{"5678"},
+			},
+			wantBody: []byte(`Hello World!`),
+		},
+		{
+			name: "bad-request",
+			response: &Response{
+				statusCode: http.StatusBadRequest,
+				body:       []byte(`{"error": "invalid foo"}`),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantHeaders:    http.Header{},
+			wantBody:       []byte(`{"error": "invalid foo"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			tt.response.parent = &Request{parent: new(Mock).Test(t)}
+
+			recorder := httptest.NewRecorder()
+
+			// Test
+			gotN, gotErr := tt.response.Write(recorder)
+
+			resp := recorder.Result()
+			gotBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unexpected error reading test response body: %v", err)
+			}
+
+			// Assertions
+			assert.NoError(t, gotErr)
+			assert.Equal(t, tt.wantStatusCode, resp.StatusCode)
+			assert.Equal(t, tt.wantHeaders, resp.Header)
+			assert.Equal(t, len(tt.wantBody), gotN)
+			assert.Equal(t, tt.wantBody, gotBody)
+		})
+	}
+}

--- a/response_test.go
+++ b/response_test.go
@@ -100,18 +100,6 @@ func TestResponse_Header(t *testing.T) {
 	}
 }
 
-func TestResponse_Times(t *testing.T) {
-	// Setup
-	req := &Request{parent: new(Mock).Test(t)}
-	resp := Response{parent: req}
-
-	// Test
-	resp.Times(4)
-
-	// Assertions
-	assert.Equal(t, 4, req.repeatability)
-}
-
 func TestResponse_Once(t *testing.T) {
 	// Setup
 	req := &Request{parent: new(Mock).Test(t)}
@@ -134,6 +122,35 @@ func TestResponse_Twice(t *testing.T) {
 
 	// Assertions
 	assert.Equal(t, 2, req.repeatability)
+}
+
+func TestResponse_Times(t *testing.T) {
+	// Setup
+	req := &Request{parent: new(Mock).Test(t)}
+	resp := Response{parent: req}
+
+	// Test
+	resp.Times(4)
+
+	// Assertions
+	assert.Equal(t, 4, req.repeatability)
+}
+
+func TestResponse_On(t *testing.T) {
+	// Setup
+	r := &Response{
+		parent:     &Request{parent: new(Mock).Test(t)},
+		statusCode: http.StatusOK,
+		body:       []byte(`Hello World!`),
+	}
+
+	// Test
+	got := r.On(http.MethodPut, "test.com/foo", []byte(`{"foo": "bar"}`))
+
+	// Assertions
+	assert.NotNil(t, got)
+	wantExpectedRequests := []*Request{got}
+	assert.Equal(t, wantExpectedRequests, r.parent.parent.ExpectedRequests)
 }
 
 func TestResponse_Write_FailWriteBody(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -6,14 +6,22 @@ import (
 	"net/http/httptest"
 )
 
+// Server simplifies the orchestration of a mock inside a handler and server.
+// It wraps the stdlib net/httptest.Server implementation and provides a
+// handler to log requests and write configured responses.
 type Server struct {
 	*httptest.Server
 
 	Mock *Mock
 
+	// Whether or not panics should be caught in the server goroutine or
+	// allowed to propagate to the parent process. If true, the panic will be
+	// printed and a 404 will be returned to the client.
 	recoverable bool
 }
 
+// makeHandler creates a standard http.HandlerFunc that may be used by a
+// regular or TLS Server to log requests and write configured responses.
 func makeHandler(s *Server) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -38,6 +46,7 @@ func makeHandler(s *Server) http.HandlerFunc {
 	)
 }
 
+// NewServer creates a new Server and associated mock.
 func NewServer() *Server {
 	s := &Server{Mock: new(Mock)}
 	s.Server = httptest.NewServer(http.HandlerFunc(makeHandler(s)))
@@ -45,6 +54,7 @@ func NewServer() *Server {
 	return s
 }
 
+// NewServer creates a new Server, configured for TLS, and associated mock.
 func NewTLSServer() *Server {
 	s := &Server{Mock: new(Mock)}
 	s.Server = httptest.NewTLSServer(http.HandlerFunc(makeHandler(s)))
@@ -52,15 +62,26 @@ func NewTLSServer() *Server {
 	return s
 }
 
+// Recoverable sets a Server as recoverable, so that panics are caught and
+// printed to stdout, with a final 404 returned to the client.
+//
+// 404 was chosen rather than 500 due to panics alnost always occurring when a
+// matching Request cannot be found. However, custom handlers can choose to
+// implement their recovery mechanism however they would like, using the
+// IsRecoverable method to access this value.
 func (s *Server) Recoverable() *Server {
 	s.recoverable = true
 	return s
 }
 
+// IsRecoverable returns whether or not the Server is considered recoverable.
 func (s *Server) IsRecoverable() bool {
 	return s.recoverable
 }
 
+// On is a convenience method to invoke the mock's On method.
+//
+//	Server.On(http.MethodDelete, "/some/path/1234")
 func (s *Server) On(method string, URL string, body []byte) *Request {
 	return s.Mock.On(method, URL, body)
 }

--- a/server.go
+++ b/server.go
@@ -1,0 +1,62 @@
+package httpmock
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+type Server struct {
+	*httptest.Server
+
+	Mock *Mock
+
+	recoverable bool
+}
+
+func makeHandler(s *Server) http.HandlerFunc {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rc := recover(); rc != nil {
+					if s.recoverable {
+						fmt.Printf("%v\n", rc)
+
+						w.WriteHeader(http.StatusNotFound)
+					} else {
+						panic(rc)
+					}
+
+				}
+			}()
+
+			response := s.Mock.Requested(r)
+			if _, err := response.Write(w); err != nil {
+				s.Mock.fail(fmt.Sprintf("failed to write response for request:\n%s\nwith error: %v", response.parent.String(), err))
+			}
+		},
+	)
+}
+
+func NewServer() *Server {
+	s := &Server{Mock: new(Mock)}
+	s.Server = httptest.NewServer(http.HandlerFunc(makeHandler(s)))
+
+	return s
+}
+
+func NewTLSServer() *Server {
+	s := &Server{Mock: new(Mock)}
+	s.Server = httptest.NewTLSServer(http.HandlerFunc(makeHandler(s)))
+
+	return s
+}
+
+func (s *Server) Recoverable() *Server {
+	s.recoverable = true
+	return s
+}
+
+func (s *Server) On(method string, URL string, body []byte) *Request {
+	return s.Mock.On(method, URL, body)
+}

--- a/server.go
+++ b/server.go
@@ -19,7 +19,7 @@ func makeHandler(s *Server) http.HandlerFunc {
 		func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if rc := recover(); rc != nil {
-					if s.recoverable {
+					if s.IsRecoverable() {
 						fmt.Printf("%v\n", rc)
 
 						w.WriteHeader(http.StatusNotFound)
@@ -55,6 +55,10 @@ func NewTLSServer() *Server {
 func (s *Server) Recoverable() *Server {
 	s.recoverable = true
 	return s
+}
+
+func (s *Server) IsRecoverable() bool {
+	return s.recoverable
 }
 
 func (s *Server) On(method string, URL string, body []byte) *Request {

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,255 @@
+package httpmock
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewServer(t *testing.T) {
+	// Test
+	s := NewServer()
+	defer s.Close()
+
+	// Assertions
+	assert.NotNil(t, s.Mock)
+	assert.NotNil(t, s.Server)
+	if s.Server != nil {
+		// Equivalent to s != TLSServer
+		assert.Nil(t, s.Server.TLS)
+		// Equivalent to the server having been Start()'ed already
+		assert.NotEmpty(t, s.Server.URL)
+	}
+}
+
+func Test_NewTLSServer(t *testing.T) {
+	// Test
+	s := NewTLSServer()
+
+	// Assertions
+	assert.NotNil(t, s.Mock)
+	assert.NotNil(t, s.Server)
+	if s.Server != nil {
+		// Equivalent to s == TLSServer
+		assert.NotNil(t, s.Server.TLS)
+		// Equivalent to the server having been Start()'ed already
+		assert.NotEmpty(t, s.Server.URL)
+	}
+}
+
+func TestServer_handler_NoMatch(t *testing.T) {
+	// Setup
+	s := NewServer().Recoverable()
+	defer s.Close()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+
+	// Test
+	request := mustNewRequest(
+		http.NewRequest(
+			http.MethodDelete,
+			fmt.Sprintf("%s/foo/1234", s.URL),
+			http.NoBody,
+		),
+	)
+	got, err := s.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assertions
+	assert.NotNil(t, got)
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+	s.Mock.AssertNotRequested(t, http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), nil)
+}
+
+func TestServer_handler_AssertRequested(t *testing.T) {
+	// Setup
+	s := NewServer().Recoverable()
+	defer s.Close()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+
+	// Test
+	request := mustNewRequest(
+		http.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf("%s/foo/1234", s.URL),
+			http.NoBody,
+		),
+	)
+	got, err := s.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBody, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Body.Close()
+
+	// Assertions
+	assert.NotNil(t, got)
+	assert.Equal(t, http.StatusOK, got.StatusCode)
+	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	s.Mock.AssertRequested(t, http.MethodGet, "/foo/1234", nil)
+}
+
+func TestServer_handler_AssertNotRequested(t *testing.T) {
+	// Setup
+	s := NewServer().Recoverable()
+	defer s.Close()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+
+	// Assertions
+	s.Mock.AssertNotRequested(t, http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), nil)
+}
+
+func TestServer_handler_AssertExpectations(t *testing.T) {
+	// Setup
+	s := NewServer().Recoverable()
+	defer s.Close()
+	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil).Twice()
+	s.On(http.MethodPut, "/foo/1234", []byte(`Hello World!`)).RespondNoContent()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`)).Once()
+	s.On(http.MethodDelete, "/foo/1234", nil).RespondNoContent()
+	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil)
+
+	// Test and Assertions
+	getRequest1 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err := s.Client().Do(getRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	getRequest2 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(`Hello World!`)))
+	got, err = s.Client().Do(putRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNoContent, got.StatusCode)
+
+	getRequest3 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBody, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	assert.Equal(t, http.StatusOK, got.StatusCode)
+
+	deleteRequest1 := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(deleteRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNoContent, got.StatusCode)
+
+	getRequest4 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	s.Mock.AssertExpectations(t)
+}
+
+func TestServer_handler_AssertNumberOfRequests(t *testing.T) {
+	// Setup
+	s := NewServer().Recoverable()
+	defer s.Close()
+	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil).Twice()
+	s.On(http.MethodPut, "/foo/1234", []byte(`Hello World!`)).RespondNoContent()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`)).Once()
+	s.On(http.MethodDelete, "/foo/1234", nil).RespondNoContent()
+	s.On(http.MethodDelete, "/bars", nil).Respond(http.StatusBadRequest, nil)
+	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil)
+
+	// Test and Assertions
+	getRequest1 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err := s.Client().Do(getRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	getRequest2 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(`Hello World!`)))
+	got, err = s.Client().Do(putRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNoContent, got.StatusCode)
+
+	getRequest3 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBody, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	assert.Equal(t, http.StatusOK, got.StatusCode)
+
+	deleteRequest1 := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(deleteRequest1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNoContent, got.StatusCode)
+
+	deleteRequest2 := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/bars", s.URL), http.NoBody))
+	got, err = s.Client().Do(deleteRequest2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, got.StatusCode)
+
+	getRequest4 := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err = s.Client().Do(getRequest4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.Body.Close()
+	assert.Equal(t, http.StatusNotFound, got.StatusCode)
+
+	s.Mock.AssertNumberOfRequests(t, http.MethodGet, "/foo/1234", 4)
+	s.Mock.AssertNumberOfRequests(t, http.MethodPut, "/foo/1234", 1)
+	s.Mock.AssertNumberOfRequests(t, http.MethodDelete, "/bars", 1)
+	s.Mock.AssertNumberOfRequests(t, http.MethodDelete, "/foo/1234", 1)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -104,7 +104,7 @@ func TestServer_handler_AssertNotRequested(t *testing.T) {
 	defer s.Close()
 	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
 
-	// Assertions
+	// Test and Assertions
 	s.Mock.AssertNotRequested(t, http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), nil)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -45,17 +45,11 @@ func TestServer_handler_NoMatch(t *testing.T) {
 	// Setup
 	s := NewServer().Recoverable()
 	defer s.Close()
-	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(testBody))
 
 	// Test
-	request := mustNewRequest(
-		http.NewRequest(
-			http.MethodDelete,
-			fmt.Sprintf("%s/foo/1234", s.URL),
-			http.NoBody,
-		),
-	)
-	got, err := s.Client().Do(request)
+	test := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err := s.Client().Do(test)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,17 +64,11 @@ func TestServer_handler_AssertRequested(t *testing.T) {
 	// Setup
 	s := NewServer().Recoverable()
 	defer s.Close()
-	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(testBody))
 
 	// Test
-	request := mustNewRequest(
-		http.NewRequest(
-			http.MethodGet,
-			fmt.Sprintf("%s/foo/1234", s.URL),
-			http.NoBody,
-		),
-	)
-	got, err := s.Client().Do(request)
+	test := mustNewRequest(http.NewRequest(http.MethodGet, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
+	got, err := s.Client().Do(test)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +82,7 @@ func TestServer_handler_AssertRequested(t *testing.T) {
 	// Assertions
 	assert.NotNil(t, got)
 	assert.Equal(t, http.StatusOK, got.StatusCode)
-	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	assert.Equal(t, []byte(testBody), gotBody)
 	s.Mock.AssertRequested(t, http.MethodGet, "/foo/1234", nil)
 }
 
@@ -102,7 +90,7 @@ func TestServer_handler_AssertNotRequested(t *testing.T) {
 	// Setup
 	s := NewServer().Recoverable()
 	defer s.Close()
-	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`))
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(testBody))
 
 	// Test and Assertions
 	s.Mock.AssertNotRequested(t, http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), nil)
@@ -113,8 +101,8 @@ func TestServer_handler_AssertExpectations(t *testing.T) {
 	s := NewServer().Recoverable()
 	defer s.Close()
 	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil).Twice()
-	s.On(http.MethodPut, "/foo/1234", []byte(`Hello World!`)).RespondNoContent()
-	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`)).Once()
+	s.On(http.MethodPut, "/foo/1234", []byte(testBody)).RespondNoContent()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(testBody)).Once()
 	s.On(http.MethodDelete, "/foo/1234", nil).RespondNoContent()
 	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil)
 
@@ -135,7 +123,7 @@ func TestServer_handler_AssertExpectations(t *testing.T) {
 	got.Body.Close()
 	assert.Equal(t, http.StatusNotFound, got.StatusCode)
 
-	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(`Hello World!`)))
+	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(testBody)))
 	got, err = s.Client().Do(putRequest1)
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +141,7 @@ func TestServer_handler_AssertExpectations(t *testing.T) {
 		t.Fatal(err)
 	}
 	got.Body.Close()
-	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	assert.Equal(t, []byte(testBody), gotBody)
 	assert.Equal(t, http.StatusOK, got.StatusCode)
 
 	deleteRequest1 := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))
@@ -180,8 +168,8 @@ func TestServer_handler_AssertNumberOfRequests(t *testing.T) {
 	s := NewServer().Recoverable()
 	defer s.Close()
 	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil).Twice()
-	s.On(http.MethodPut, "/foo/1234", []byte(`Hello World!`)).RespondNoContent()
-	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(`Hello World!`)).Once()
+	s.On(http.MethodPut, "/foo/1234", []byte(testBody)).RespondNoContent()
+	s.On(http.MethodGet, "/foo/1234", nil).RespondOK([]byte(testBody)).Once()
 	s.On(http.MethodDelete, "/foo/1234", nil).RespondNoContent()
 	s.On(http.MethodDelete, "/bars", nil).Respond(http.StatusBadRequest, nil)
 	s.On(http.MethodGet, "/foo/1234", nil).Respond(http.StatusNotFound, nil)
@@ -203,7 +191,7 @@ func TestServer_handler_AssertNumberOfRequests(t *testing.T) {
 	got.Body.Close()
 	assert.Equal(t, http.StatusNotFound, got.StatusCode)
 
-	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(`Hello World!`)))
+	putRequest1 := mustNewRequest(http.NewRequest(http.MethodPut, fmt.Sprintf("%s/foo/1234", s.URL), strings.NewReader(testBody)))
 	got, err = s.Client().Do(putRequest1)
 	if err != nil {
 		t.Fatal(err)
@@ -221,7 +209,7 @@ func TestServer_handler_AssertNumberOfRequests(t *testing.T) {
 		t.Fatal(err)
 	}
 	got.Body.Close()
-	assert.Equal(t, []byte(`Hello World!`), gotBody)
+	assert.Equal(t, []byte(testBody), gotBody)
 	assert.Equal(t, http.StatusOK, got.StatusCode)
 
 	deleteRequest1 := mustNewRequest(http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/foo/1234", s.URL), http.NoBody))


### PR DESCRIPTION
This PR includes the initial set of features for `httpmock`. These features should enable basic mocking support for any project, including:

- [x] Predetermined responses to requests
- [x] Log received requests
- [x] Assert that received requests are expected
- [x] Assert number of requests for a particular HTTP method/path combination
- [x] Simple test server (extends `net/httptest.Server`) to assert requests and return Predetermined responses