### PR TITLE
feat: safe request body reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ method.
 
 ## Features
 
+### SafeReadBody
+
+`httpmock.SafeReadBody` will read a `http.Request.Body` and resets the `http.Request.Body` with a fresh `io.Reader` so
+that subsequent logic may also read the body.
+
 ### `httpmock.Mock`
 
 #### On

--- a/mock.go
+++ b/mock.go
@@ -141,7 +141,7 @@ func (m *Mock) findClosestRequest(received *http.Request) (*Request, string) {
 func (m *Mock) Requested(received *http.Request) *Response {
 	m.mutex.Lock()
 
-	receivedBody, err := readHTTPRequestBody(received)
+	receivedBody, err := SafeReadBody(received)
 	if err != nil {
 		m.mutex.Unlock()
 		m.fail("\nassert: httpmock: Failed to read requested body. Error: %v", err)

--- a/request.go
+++ b/request.go
@@ -181,9 +181,8 @@ func (r *Request) Matches(matchers ...RequestMatcher) *Request {
 	return r
 }
 
-// readHTTPRequestBody reads the body of a HTTP request and resets the
-// request's body so that it may be read again afterward.
-func readHTTPRequestBody(received *http.Request) ([]byte, error) {
+// SafeReadBody reads the body of a HTTP request and resets the request's body so that it may be read again afterward.
+func SafeReadBody(received *http.Request) ([]byte, error) {
 	// Read request body and reset it for the next comparison
 	body, err := io.ReadAll(received.Body)
 	if err != nil {
@@ -392,7 +391,7 @@ func (r *Request) diffBody(received *http.Request) (string, int) {
 	var output string
 	var differences int
 
-	otherBody, err := readHTTPRequestBody(received)
+	otherBody, err := SafeReadBody(received)
 	if err != nil {
 		return err.Error(), 1
 	}


### PR DESCRIPTION
This PR makes a private function public so that users may read the request body in matcher functions and elsewhere without affecting the request body itself.