### PR TITLE
feat: custom response writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ respWriter := func(w http.ResponseWriter, r *http.Request) (int, error) {
 Mock.On(http.MethodGet, "/some/path/1234?page=3&limit=20", nil).RespondUsing(respWriter)
 ```
 
+### `httpmock.Response`
+
+#### Header
+
+Use `httpmock.Response.Header()` to set headers on the response. Multiple values may be passed for the header's value.
+However, multiple invocations against the same header will overwrite previous values with the most recent values.
+
+```go
+Mock.On(http.MethodGet, "/some/path", nil).RespondOK([]byte(`{"id": "1234"}`)).Header("next", "abcd")
+```
+
 ### `httpmock.Server`
 
 #### Recoverable, IsRecoverable

--- a/README.md
+++ b/README.md
@@ -188,6 +188,37 @@ Mock.On(http.MethodGet, "/some/path/1234").Respond(http.StatusNotFound, []byte(`
 In the future, more convenience methods may be added if they are common, clearly defined, and enhance the readability
 and simplification of the mock response configuration.
 
+#### RespondUsing
+
+If more complex functionality is needed than `Respond` can provide, `httpmock` allows for custom response
+implementations with this method. If `RespondUsing` is called, all of the other `Respond` configurations
+are ignored.
+
+```go
+// respWriter calculates the count based on the page and limit and returns these values in the response.
+respWriter := func(w http.ResponseWriter, r *http.Request) (int, error) {
+	v := r.URL.Query().Get("limit")
+
+	limit := 10
+	if v != "" {
+		limit, _ = strconv.Atoi(v)
+	}
+
+	v = r.URL.Query().Get("page")
+
+	var count, page int
+	if v != "" {
+		page, _ := strconv.Atoi(v)
+		count = limit * page
+	}
+
+	w.WriteHeader(http.StatusOK)
+	return w.Write([]byte(`{"count": %d, "page": %d, "limit": %d, "result": {...}}`, count, page, limit))
+}
+
+Mock.On(http.MethodGet, "/some/path/1234?page=3&limit=20", nil).RespondUsing(respWriter)
+```
+
 ### `httpmock.Server`
 
 #### Recoverable, IsRecoverable

--- a/mock.go
+++ b/mock.go
@@ -14,12 +14,12 @@ import (
 )
 
 // tHelper is a minimal interface that expects a type to satisfy the
-// testing.TB.Helper method.
+// [testing.TB] Helper method.
 type tHelper interface {
 	Helper()
 }
 
-// Mock is the workhorse used to track activity of a server's request.
+// Mock is the workhorse used to track activity of a server's requesst.
 // For an example of its usage, refer to the README.
 type Mock struct {
 	// Represents the requests that are expected to be received.
@@ -35,7 +35,7 @@ type Mock struct {
 	mutex sync.Mutex
 }
 
-// On starts a description of an expectation of the specified Request being
+// On starts a description of an expectation of the specified [Request] being
 // received.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234")
@@ -59,7 +59,7 @@ func (m *Mock) On(method string, URL string, body []byte) *Request {
 	return expected
 }
 
-// Test sets the test struct variable of the mock object.
+// Test sets the test struct variable of the [Mock] object.
 func (m *Mock) Test(t mock.TestingT) *Mock {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -82,18 +82,18 @@ func (m *Mock) fail(format string, args ...interface{}) {
 }
 
 // expectedRequests provides a safe mechanism for viewing and modifying the list
-// of expected Requests.
+// of expected [Request]'s.
 func (m *Mock) expectedRequests() []*Request {
 	return append([]*Request{}, m.ExpectedRequests...)
 }
 
 // expectedRequests provides a safe mechanism for viewing and modifying the list
-// of received Requests.
+// of received [Request]'s.
 func (m *Mock) requests() []Request {
 	return append([]Request{}, m.Requests...)
 }
 
-// findExpectedRequest finds the first Request that exactly matches a received
+// findExpectedRequest finds the first [Request] that exactly matches a received
 // request and does not have its repeatability disabled.
 func (m *Mock) findExpectedRequest(actual *http.Request) (int, *Request) {
 	var expected *Request
@@ -111,12 +111,12 @@ func (m *Mock) findExpectedRequest(actual *http.Request) (int, *Request) {
 	return -1, expected
 }
 
-// findClosestRequest finds the first request that most closely matches a
-// received request.
+// findClosestRequest finds the first [Request] that most closely matches a
+// received [http.Request].
 //
 // This method should only be used if there is no exact match of a received
-// request to the list of expected Requests. If a closest match is found, it is
-// returned, along with a formatted string of the differences.
+// request to the list of expected [Request]'s. If a closest match is found,
+// it is returned, along with a formatted string of the differences.
 func (m *Mock) findClosestRequest(received *http.Request) (*Request, string) {
 	var bestMatch matchCandidate
 
@@ -135,9 +135,9 @@ func (m *Mock) findClosestRequest(received *http.Request) (*Request, string) {
 	return bestMatch.request, bestMatch.mismatch
 }
 
-// Requested tells the mock that a request has been received and gets a response
-// to return. Panics if the request is unexpected (i.e. not preceded by
-// appropriate .On .Respond() calls)
+// Requested tells the mock that a [http.Request] has been received and gets a
+// response to return. Panics if the request is unexpected (i.e. not preceded
+// by appropriate [Mock.On] calls).
 func (m *Mock) Requested(received *http.Request) *Response {
 	m.mutex.Lock()
 
@@ -203,20 +203,20 @@ func (m *Mock) Requested(received *http.Request) *Response {
 	return expected.response
 }
 
-// matchCandidate holds details about possible Request matches for a received
-// request.
+// matchCandidate holds details about possible [Request] matches for a received
+// [http.Request].
 type matchCandidate struct {
-	// Matched Request
+	// Matched [*Request]
 	request *Request
 
 	// Formatted string showing differences
 	mismatch string
 
-	// Number of differences between match candidate and received request.
+	// Number of differences between matchCandidate and received http.Request.
 	diffCount int
 }
 
-// isBetterMatchThan compares two matchCandidates to determine whether the
+// isBetterMatchThan compares two matchCandidate's to determine whether the
 // referenced candidate is better than the other candidate.
 func (mc matchCandidate) isBetterMatchThan(other matchCandidate) bool {
 	if mc.request == nil {
@@ -238,8 +238,9 @@ func (mc matchCandidate) isBetterMatchThan(other matchCandidate) bool {
 	return false
 }
 
-// AssertExpectations assert that everything specified with On and Respond was
-// in fact requested as expected. Requests may have occurred in any order.
+// AssertExpectations assert that everything specified with [Mock.On] and
+// [Request.Respond] was in fact requested as expected. [Request]'s may have
+// occurred in any order.
 func (m *Mock) AssertExpectations(t mock.TestingT) bool {
 	if th, ok := t.(tHelper); ok {
 		th.Helper()
@@ -362,7 +363,7 @@ func (m *Mock) AssertNotRequested(t mock.TestingT, method string, path string, b
 	return true
 }
 
-// checkExpectation checks whether an expected Request was received, and
+// checkExpectation checks whether an expected [Request] was received,
 // whether it received the expected number of times.
 func (m *Mock) checkExpectation(expected *Request) (bool, string) {
 	if (!m.checkWasRequested(expected.method, expected.url, expected.body) && expected.totalRequests == 0) || (expected.repeatability > 0) {
@@ -371,7 +372,7 @@ func (m *Mock) checkExpectation(expected *Request) (bool, string) {
 	return true, fmt.Sprintf("PASS:\t%s %s\n\t(%d) %s", expected.method, expected.url, len(expected.body), trimBody(expected.body))
 }
 
-// checkWasRequested checks whether a set of request parameters was received.
+// checkWasRequested checks whether a set of [Request] parameters was received.
 func (m *Mock) checkWasRequested(method string, URL *url.URL, body []byte) bool {
 	tempReceived := &http.Request{
 		Method: method,

--- a/request.go
+++ b/request.go
@@ -32,10 +32,11 @@ var (
 	fmtEqual    = "=="
 )
 
-// RequestMatcher is used by the `Request.Matches` method to match a HTTP request.
+// RequestMatcher is used by the [Request.Matches] method to match a
+// [http.Request].
 type RequestMatcher func(received *http.Request) (output string, differences int)
 
-// Request represents a HTTP request and is used for setting expectations,
+// Request represents a [http.Request] and is used for setting expectations,
 // as well as recording activity.
 type Request struct {
 	parent *Mock
@@ -74,12 +75,12 @@ func newRequest(parent *Mock, method string, URL *url.URL, body []byte) *Request
 	}
 }
 
-// lock is a convenience method to lock the parent Mock's mutex.
+// lock is a convenience method to lock the parent [Mock]'s mutex.
 func (r *Request) lock() {
 	r.parent.mutex.Lock()
 }
 
-// unlock is a convenience method to unlock the parent Mock's mutex.
+// unlock is a convenience method to unlock the parent [Mock]'s mutex.
 func (r *Request) unlock() {
 	r.parent.mutex.Unlock()
 }
@@ -105,7 +106,7 @@ func (r *Request) Respond(statusCode int, body []byte) *Response {
 // RespondOK is a convenience method that sets the status code as 200 and
 // the provided body.
 //
-//	Mock.On(http.GetMethod, "/some/path").RespondOK([]byte(`{"foo", "bar"}`)])
+//	Mock.On(http.GetMethod, "/some/path").RespondOK([]byte(`{"foo", "bar"}`))
 func (r *Request) RespondOK(body []byte) *Response {
 	return r.Respond(http.StatusOK, body)
 }
@@ -117,10 +118,10 @@ func (r *Request) RespondNoContent() *Response {
 	return r.Respond(http.StatusNoContent, nil)
 }
 
-// RespondUsing overrides the [Respond] functionality by allowing a custom
-// writer to be invoked instead of the typical writing functionality.
+// RespondUsing overrides the [Request.Respond] functionality by allowing a
+// custom writer to be invoked instead of the typical writing functionality.
 //
-// Note: The `writer“ is responsible for the entire response, including
+// Note: The `writer` is responsible for the entire response, including
 // headers, status code, and body.
 func (r *Request) RespondUsing(writer ResponseWriter) *Response {
 	resp := &Response{
@@ -136,21 +137,21 @@ func (r *Request) RespondUsing(writer ResponseWriter) *Response {
 	return resp
 }
 
-// Once indicates that the mock should only return the response once.
+// Once indicates that the [Mock] should only return the response once.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").Once()
 func (r *Request) Once() *Request {
 	return r.Times(1)
 }
 
-// Twice indicates that the mock should only return the response twice.
+// Twice indicates that the [Mock] should only return the response twice.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").Twice()
 func (r *Request) Twice() *Request {
 	return r.Times(2)
 }
 
-// Times indicates that the mock should only return the indicated number
+// Times indicates that the [Mock] should only return the indicated number
 // of times.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").Times(5)
@@ -162,8 +163,9 @@ func (r *Request) Times(i int) *Request {
 	return r
 }
 
-// Matches adds one or more RequestMatcher's to the Request. RequestMatcher's are called
-// in FIFO order after the HTTP method, URL, and body have been matched.
+// Matches adds one or more [RequestMatcher]'s to the Request.
+// [RequestMatcher]'s are called in FIFO order after the HTTP method, URL, and
+// body have been matched.
 //
 //	func queryAtLeast(key string, minValue int) RequestMatcher {
 //		fn := func(received *http.Request) (output string, differences int) {
@@ -200,7 +202,8 @@ func (r *Request) Matches(matchers ...RequestMatcher) *Request {
 	return r
 }
 
-// SafeReadBody reads the body of a HTTP request and resets the request's body so that it may be read again afterward.
+// SafeReadBody reads the body of a [http.Request] and resets the
+// [http.Request]'s body so that it may be read again afterward.
 func SafeReadBody(received *http.Request) ([]byte, error) {
 	// Read request body and reset it for the next comparison
 	body, err := io.ReadAll(received.Body)
@@ -222,9 +225,9 @@ func diffMissing(v string) (string, bool) {
 	return v, true
 }
 
-// diffMethod detects differences between a Request's HTTP method and a HTTP
-// request's HTTP method. It responds with a formatted string of the difference
-// and the calculated number of differences.
+// diffMethod detects differences between a [Request]'s HTTP method and a
+// [http.Request]'s HTTP method. It responds with a formatted string of the
+// difference and the calculated number of differences.
 func (r *Request) diffMethod(received *http.Request) (string, int) {
 	var output string
 	var differences int
@@ -251,14 +254,14 @@ func (r *Request) diffMethod(received *http.Request) (string, int) {
 	return output, differences
 }
 
-// diffQuery detects differences between a Request's query parameters and a
-// HTTP request's query parameters. It responds with a formatted string of the
+// diffQuery detects differences between a [Request]'s query parameters and a
+// [http.Request]'s query parameters. It responds with a formatted string of the
 // differences and the calculated number of differences.
 //
 // Query Logic:
-//   - If Request query is empty, don't compare query parameters at all
-//   - Otherwise, only compare query parameters found in Request; ignore query
-//     parameters in HTTP request that are not enumerated in the Request.
+//   - If [Request] query is empty, don't compare query parameters at all.
+//   - Otherwise, only compare query parameters found in [Request]; ignore query
+//     parameters in [http.Request] that are not enumerated in the [Request].
 func (r *Request) diffQuery(received *http.Request) (string, int) {
 	var output string
 	var differences int
@@ -303,8 +306,8 @@ func (r *Request) diffQuery(received *http.Request) (string, int) {
 	return output, differences
 }
 
-// diffURL detects differences between a Request's URL and an
-// HTTP request's URL. It responds with a formatted string of the
+// diffURL detects differences between a [Request]'s URL and a
+// [http.Request]'s URL. It responds with a formatted string of the
 // differences and the calculated number of differences.
 //
 // Ignored URL Fields:
@@ -403,9 +406,9 @@ func trimBody(body []byte) string {
 	return o
 }
 
-// diffBody detects differences between a Request's body and a HTTP request's
-// body. It responds with a formatted string of the differences and the
-// calculated number of differences.
+// diffBody detects differences between a [Request]'s body and a
+// [http.Request]'s body. It responds with a formatted string of
+// the differences and the calculated number of differences.
 func (r *Request) diffBody(received *http.Request) (string, int) {
 	var output string
 	var differences int
@@ -441,9 +444,9 @@ func (r *Request) diffBody(received *http.Request) (string, int) {
 	return output, differences
 }
 
-// diff detects differences between a Request and a HTTP request. It responds
-// with a formatted string of the differences and the calculated number of
-// differences.
+// diff detects differences between a [Request] and a [http.Request]. It
+// responds with a formatted string of the differences and the calculated
+// number of differences.
 func (r *Request) diff(received *http.Request) (string, int) {
 	output := "\n"
 	var differences int
@@ -472,7 +475,7 @@ func (r *Request) diff(received *http.Request) (string, int) {
 	return output, differences
 }
 
-// String computes a formatted string representing a Request.
+// String computes a formatted string representing a [Request].
 func (r *Request) String() string {
 	var output []string
 

--- a/request.go
+++ b/request.go
@@ -117,6 +117,25 @@ func (r *Request) RespondNoContent() *Response {
 	return r.Respond(http.StatusNoContent, nil)
 }
 
+// RespondUsing overrides the [Respond] functionality by allowing a custom
+// writer to be invoked instead of the typical writing functionality.
+//
+// Note: The `writer“ is responsible for the entire response, including
+// headers, status code, and body.
+func (r *Request) RespondUsing(writer ResponseWriter) *Response {
+	resp := &Response{
+		parent: r,
+		writer: writer,
+	}
+
+	r.lock()
+	defer r.unlock()
+
+	r.response = resp
+
+	return resp
+}
+
 // Once indicates that the mock should only return the response once.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").Once()

--- a/request_test.go
+++ b/request_test.go
@@ -234,7 +234,7 @@ func TestRequest_RespondUsing(t *testing.T) {
 
 	testWriter := func(w http.ResponseWriter, r *http.Request) (int, error) {
 		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte(`And stay out!`))
+		_, _ = w.Write([]byte(`And stay out!`))
 		return 13, nil
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -225,6 +226,41 @@ func TestRequest_RespondNoContent(t *testing.T) {
 	}
 	assert.Equal(t, want, got)
 	assert.Equal(t, got, r.response)
+}
+
+func TestRequest_RespondUsing(t *testing.T) {
+	// Setup
+	r := &Request{parent: new(Mock)}
+
+	testWriter := func(w http.ResponseWriter, r *http.Request) (int, error) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`And stay out!`))
+		return 13, nil
+	}
+
+	// Test
+	got := r.RespondUsing(testWriter)
+
+	// Assertions
+	assert.Equal(t, got, r.response)
+	assert.Zero(t, got.statusCode)
+	assert.Empty(t, got.header)
+	assert.Empty(t, got.body)
+	assert.NotNil(t, got.writer)
+
+	// Instead of comparing function pointers, run the function and assert its
+	// output.
+	recorder := httptest.NewRecorder()
+	gotN, gotErr := got.writer(recorder, &http.Request{})
+	assert.Equal(t, 13, gotN)
+	assert.Nil(t, gotErr)
+	gotResult := recorder.Result()
+	gotResultBody, err := io.ReadAll(gotResult.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading response: %v", err)
+	}
+	defer gotResult.Body.Close()
+	assert.Equal(t, "And stay out!", string(gotResultBody))
 }
 
 func TestRequest_Once(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -7,8 +7,8 @@ import (
 
 var ErrWriteReturnBody = errors.New("error writing return body")
 
-// ResponseWriter writes a HTTP response and returns the number of bytes written
-// and whether or not the operation encountered an error.
+// ResponseWriter writes a [http.Response] and returns the number of bytes
+// written and whether or not the operation encountered an error.
 //
 // [*http.Request] is provided as an argument so that the response writer can
 // use information from the request when crafting the response. If the
@@ -42,12 +42,12 @@ func newResponse(parent *Request, statusCode int, body []byte) *Response {
 	}
 }
 
-// lock is a convenience method to lock the grandparent mock's mutex.
+// lock is a convenience method to lock the grandparent [Mock]'s mutex.
 func (r *Response) lock() {
 	r.parent.parent.mutex.Lock()
 }
 
-// unlock is a convenience method to unlock the grandparent mock's mutex.
+// unlock is a convenience method to unlock the grandparent [Mock]'s mutex.
 func (r *Response) unlock() {
 	r.parent.parent.mutex.Unlock()
 }
@@ -63,7 +63,7 @@ func (r *Response) Header(key string, value string, values ...string) *Response 
 	return r
 }
 
-// Once is a convenience method which indicates that the grandparent mock
+// Once is a convenience method which indicates that the grandparent [Mock]
 // should only expect the parent request once.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Once()
@@ -71,7 +71,7 @@ func (r *Response) Once() *Request {
 	return r.parent.Once()
 }
 
-// Twice is a convenience method which indicates that the grandparent mock
+// Twice is a convenience method which indicates that the grandparent [Mock]
 // should only expect the parent request twice.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Twice()
@@ -79,7 +79,7 @@ func (r *Response) Twice() *Request {
 	return r.parent.Twice()
 }
 
-// Times is a convenience method which indicates that the grandparent mock
+// Times is a convenience method which indicates that the grandparent [Mock]
 // should only expect the parent request the indicated number of times.
 //
 //	Mock.On(http.MethodDelete, "/some/path/1234").RespondNoContent().Times(5)
@@ -87,7 +87,7 @@ func (r *Response) Times(i int) *Request {
 	return r.parent.Times(i)
 }
 
-// On chains a new expectation description onto the grandparent mock. This
+// On chains a new expectation description onto the grandparent [Mock]. This
 // allows syntax like:
 //
 //	Mock.

--- a/response_test.go
+++ b/response_test.go
@@ -246,7 +246,7 @@ func TestResponse_Write(t *testing.T) {
 				body:       []byte("HELP"),
 				writer: func(w http.ResponseWriter, r *http.Request) (int, error) {
 					w.WriteHeader(http.StatusBadRequest)
-					w.Write([]byte(`{"error": "invalid foo"}`))
+					_, _ = w.Write([]byte(`{"error": "invalid foo"}`))
 					return 24, nil
 				},
 			},

--- a/response_test.go
+++ b/response_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// badResponseWriter implements the http.ResponseWriter interface, but always fails to write.
+// badResponseWriter implements the [http.ResponseWriter] interface, but always
+// fails to write.
 type badResponseWriter struct{}
 
 func (brw *badResponseWriter) Header() http.Header               { return http.Header{} }

--- a/response_test.go
+++ b/response_test.go
@@ -163,7 +163,7 @@ func TestResponse_Write_FailWriteBody(t *testing.T) {
 	}
 
 	// Test
-	gotN, gotErr := response.Write(&badResponseWriter{})
+	gotN, gotErr := response.Write(&badResponseWriter{}, nil)
 
 	// Assertions
 	assert.Equal(t, -1, gotN)
@@ -235,6 +235,24 @@ func TestResponse_Write(t *testing.T) {
 			wantHeaders:    http.Header{},
 			wantBody:       []byte(`{"error": "invalid foo"}`),
 		},
+		{
+			name: "response-writer",
+			response: &Response{
+				// Set statusCode, header, and body to verify they are not used
+				// during response writing.
+				statusCode: http.StatusInternalServerError,
+				header:     http.Header{"X-Request-Id": []string{"5678"}},
+				body:       []byte("HELP"),
+				writer: func(w http.ResponseWriter, r *http.Request) (int, error) {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(`{"error": "invalid foo"}`))
+					return 24, nil
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantHeaders:    http.Header{},
+			wantBody:       []byte(`{"error": "invalid foo"}`),
+		},
 	}
 
 	for _, tt := range tests {
@@ -245,7 +263,7 @@ func TestResponse_Write(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			// Test
-			gotN, gotErr := tt.response.Write(recorder)
+			gotN, gotErr := tt.response.Write(recorder, nil)
 
 			response := recorder.Result()
 			gotBody, err := io.ReadAll(response.Body)

--- a/server.go
+++ b/server.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 )
 
-// Server simplifies the orchestration of a mock inside a handler and server.
-// It wraps the stdlib net/httptest.Server implementation and provides a
+// Server simplifies the orchestration of a [Mock] inside a handler and server.
+// It wraps the stdlib [httptest.Server] implementation and provides a
 // handler to log requests and write configured responses.
 type Server struct {
 	*httptest.Server
@@ -20,8 +20,8 @@ type Server struct {
 	recoverable bool
 }
 
-// makeHandler creates a standard http.HandlerFunc that may be used by a
-// regular or TLS Server to log requests and write configured responses.
+// makeHandler creates a standard [http.HandlerFunc] that may be used by a
+// regular or TLS [Server] to log requests and write configured responses.
 func makeHandler(s *Server) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +46,7 @@ func makeHandler(s *Server) http.HandlerFunc {
 	)
 }
 
-// NewServer creates a new Server and associated mock.
+// NewServer creates a new [Server] and associated [Mock].
 func NewServer() *Server {
 	s := &Server{Mock: new(Mock)}
 	s.Server = httptest.NewServer(http.HandlerFunc(makeHandler(s)))
@@ -54,7 +54,7 @@ func NewServer() *Server {
 	return s
 }
 
-// NewServer creates a new Server, configured for TLS, and associated mock.
+// NewServer creates a new [Server], configured for TLS, and associated [Mock].
 func NewTLSServer() *Server {
 	s := &Server{Mock: new(Mock)}
 	s.Server = httptest.NewTLSServer(http.HandlerFunc(makeHandler(s)))
@@ -62,24 +62,24 @@ func NewTLSServer() *Server {
 	return s
 }
 
-// Recoverable sets a Server as recoverable, so that panics are caught and
+// Recoverable sets a [Server] as recoverable, so that panics are caught and
 // printed to stdout, with a final 404 returned to the client.
 //
-// 404 was chosen rather than 500 due to panics alnost always occurring when a
-// matching Request cannot be found. However, custom handlers can choose to
+// 404 was chosen rather than 500 due to panics almost always occurring when a
+// matching [Request] cannot be found. However, custom handlers can choose to
 // implement their recovery mechanism however they would like, using the
-// IsRecoverable method to access this value.
+// [Server.IsRecoverable] method to access this value.
 func (s *Server) Recoverable() *Server {
 	s.recoverable = true
 	return s
 }
 
-// IsRecoverable returns whether or not the Server is considered recoverable.
+// IsRecoverable returns whether or not the [Server] is considered recoverable.
 func (s *Server) IsRecoverable() bool {
 	return s.recoverable
 }
 
-// On is a convenience method to invoke the mock's On method.
+// On is a convenience method to invoke the [Mock.On] method.
 //
 //	Server.On(http.MethodDelete, "/some/path/1234")
 func (s *Server) On(method string, URL string, body []byte) *Request {

--- a/server.go
+++ b/server.go
@@ -39,7 +39,7 @@ func makeHandler(s *Server) http.HandlerFunc {
 			}()
 
 			response := s.Mock.Requested(r)
-			if _, err := response.Write(w); err != nil {
+			if _, err := response.Write(w, r); err != nil {
 				s.Mock.fail("failed to write response for request:\n%s\nwith error: %v", response.parent.String(), err)
 			}
 		},


### PR DESCRIPTION
This PR adds support for a custom response writer using the `Request.RespondUsing()` method. Additionally, updated docs with missing feature and package links.