### PR TITLE
feat: custom handler config

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,10 @@ Mock.On(http.MethodGet, "/some/path", nil).RespondOK([]byte(`{"id": "1234"}`)).H
 
 `httpmock.Server` is a glorified version of `httptest.Server` with a default handler. With both server types, the
 server runs as a goroutine. The default behavior is to log the panic details and recover from it. However, an
-implementation can set `NotRecoverable()` to indicate to the handler that an unmatched request should cause the server
-to panic outside of the server goroutine and into the main process.
+implementation can set `NotRecoverable()` to indicate to the default or custom handler that an unmatched request
+should cause the server to panic outside of the server goroutine and into the main process.
+
+If writing a custom handler, the handler should react to a panic based on the server's `IsRecoverable()` response.
 
 ## Installation
 

--- a/server.go
+++ b/server.go
@@ -20,6 +20,13 @@ type Server struct {
 	ignorePanic bool
 }
 
+// ServerConfig contains settings for configuring a [Server]. It is used with
+// [NewServerWithConfig]. For default behavior, use [NewServer].
+type ServerConfig struct {
+	// Create TLS-configured server
+	TLS bool
+}
+
 // makeHandler creates a standard [http.HandlerFunc] that may be used by a
 // regular or TLS [Server] to log requests and write configured responses.
 func makeHandler(s *Server) http.HandlerFunc {
@@ -54,10 +61,15 @@ func NewServer() *Server {
 	return s
 }
 
-// NewServer creates a new [Server], configured for TLS, and associated [Mock].
-func NewTLSServer() *Server {
+func NewServerWithConfig(cfg ServerConfig) *Server {
 	s := &Server{Mock: new(Mock)}
-	s.Server = httptest.NewTLSServer(http.HandlerFunc(makeHandler(s)))
+
+	handler := http.HandlerFunc(makeHandler(s))
+	if cfg.TLS {
+		s.Server = httptest.NewTLSServer(handler)
+	} else {
+		s.Server = httptest.NewServer(handler)
+	}
 
 	return s
 }

--- a/server_test.go
+++ b/server_test.go
@@ -17,13 +17,13 @@ func Test_NewServer(t *testing.T) {
 
 	// Assertions
 	assert.NotNil(t, s.Mock)
-	assert.NotNil(t, s.Server)
-	if s.Server != nil {
-		// Equivalent to s != TLSServer
-		assert.Nil(t, s.Server.TLS)
-		// Equivalent to the server having been Start()'ed already
-		assert.NotEmpty(t, s.Server.URL)
+	if s.Server == nil {
+		t.Fatalf("unexpected nil Server")
 	}
+	// Equivalent to s != TLSServer
+	assert.Nil(t, s.Server.TLS)
+	// Equivalent to the server having been Start()'ed already
+	assert.NotEmpty(t, s.Server.URL)
 }
 
 func Test_NewServerWithConfig_TLS(t *testing.T) {
@@ -35,13 +35,42 @@ func Test_NewServerWithConfig_TLS(t *testing.T) {
 
 	// Assertions
 	assert.NotNil(t, s.Mock)
-	assert.NotNil(t, s.Server)
-	if s.Server != nil {
-		// Equivalent to s == TLSServer
-		assert.NotNil(t, s.Server.TLS)
-		// Equivalent to the server having been Start()'ed already
-		assert.NotEmpty(t, s.Server.URL)
+	if s.Server == nil {
+		t.Fatalf("unexpected nil Server")
 	}
+	// Equivalent to s == TLSServer
+	assert.NotNil(t, s.Server.TLS)
+	// Equivalent to the server having been Start()'ed already
+	assert.NotEmpty(t, s.Server.URL)
+}
+
+func Test_NewServerWithConfig_CustomHandler(t *testing.T) {
+	// Setup
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}
+	cfg := ServerConfig{Handler: handler}
+
+	// Test
+	s := NewServerWithConfig(cfg)
+	s.On(AnyMethod, "/", nil).RespondOK([]byte(``))
+
+	// Assertions
+	assert.NotNil(t, s.Mock)
+	if s.Server == nil {
+		t.Fatalf("unexpected nil Server")
+	}
+	// Equivalent to s != TLSServer
+	assert.Nil(t, s.Server.TLS)
+	// Equivalent to the server having been Start()'ed already
+	assert.NotEmpty(t, s.Server.URL)
+
+	resp, err := s.Client().Get(s.URL)
+	if err != nil {
+		t.Fatalf("unexpecrted failure when reading response: %v", err)
+	}
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 func TestServer_NotRecoverable(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -26,9 +26,12 @@ func Test_NewServer(t *testing.T) {
 	}
 }
 
-func Test_NewTLSServer(t *testing.T) {
+func Test_NewServerWithConfig_TLS(t *testing.T) {
+	// Setup
+	cfg := ServerConfig{TLS: true}
+
 	// Test
-	s := NewTLSServer()
+	s := NewServerWithConfig(cfg)
 
 	// Assertions
 	assert.NotNil(t, s.Mock)


### PR DESCRIPTION
Closes #13 .

This PR adds support for custom Server handlers via a new method, `NewServerWithConfig`.

## Other Changes

- feat: `NewServerWithConfig` function to configure non-default Servers
- refactor: `NewTLSServer` removed and is configureable via the function `NewServerWithConfig`